### PR TITLE
feat: tmux session persistence for terminal tabs

### DIFF
--- a/.superpowers/brainstorm/68424-1774250840/.server-info
+++ b/.superpowers/brainstorm/68424-1774250840/.server-info
@@ -1,0 +1,1 @@
+{"type":"server-started","port":61413,"host":"127.0.0.1","url_host":"localhost","url":"http://localhost:61413","screen_dir":"/Users/gilles/Documents/trailblaze/deckard/.superpowers/brainstorm/68424-1774250840"}

--- a/.superpowers/brainstorm/68424-1774250840/theme-picker.html
+++ b/.superpowers/brainstorm/68424-1774250840/theme-picker.html
@@ -1,0 +1,113 @@
+<h2>Theme Picker Design</h2>
+<p class="subtitle">Each theme shown as a card with its name and a mini terminal preview using the actual colors. Click to select your preferred layout.</p>
+
+<div class="options">
+  <div class="option" data-choice="3col" onclick="toggleSelect(this)">
+    <div class="letter">A</div>
+    <div class="content">
+      <h3>3-Column Grid</h3>
+      <p>Wider cards, more preview detail. ~3 themes visible per row.</p>
+    </div>
+  </div>
+  <div class="option" data-choice="4col" onclick="toggleSelect(this)">
+    <div class="letter">B</div>
+    <div class="content">
+      <h3>4-Column Grid</h3>
+      <p>More themes visible at once, slightly smaller previews. Good balance.</p>
+    </div>
+  </div>
+  <div class="option" data-choice="5col" onclick="toggleSelect(this)">
+    <div class="letter">C</div>
+    <div class="content">
+      <h3>5-Column Grid</h3>
+      <p>Maximum density, compact previews. Best for quickly scanning many themes.</p>
+    </div>
+  </div>
+</div>
+
+<h3 style="margin-top: 32px;">Preview: How the theme cards would look</h3>
+<p class="subtitle">Each card shows the theme name and a mini terminal with colored sample text</p>
+
+<div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-top: 16px;">
+
+  <!-- Dracula -->
+  <div style="border-radius: 8px; overflow: hidden; border: 1px solid #444; cursor: pointer;">
+    <div style="background: #282a36; padding: 8px 10px; font-family: 'SF Mono', 'Menlo', monospace; font-size: 11px; line-height: 1.5;">
+      <span style="color: #50fa7b;">~</span><span style="color: #f8f8f2;"> $ </span><span style="color: #8be9fd;">ls</span><span style="color: #f8f8f2;"> -la</span><br>
+      <span style="color: #6272a4;">drwxr-xr-x</span> <span style="color: #bd93f9;">5</span> <span style="color: #f1fa8c;">user</span> <span style="color: #f8f8f2;">staff</span> <span style="color: #ff79c6;">160</span><br>
+      <span style="color: #ff5555;">error:</span> <span style="color: #f8f8f2;">something went wrong</span><br>
+      <span style="color: #50fa7b;">~</span><span style="color: #f8f8f2;"> $ </span><span style="color: #6272a4;">▌</span>
+    </div>
+    <div style="background: #21222c; padding: 6px 10px; color: #f8f8f2; font-size: 12px; font-weight: 500; border-top: 1px solid #44475a;">
+      Dracula
+    </div>
+  </div>
+
+  <!-- Nord -->
+  <div style="border-radius: 8px; overflow: hidden; border: 1px solid #444; cursor: pointer;">
+    <div style="background: #2e3440; padding: 8px 10px; font-family: 'SF Mono', 'Menlo', monospace; font-size: 11px; line-height: 1.5;">
+      <span style="color: #a3be8c;">~</span><span style="color: #d8dee9;"> $ </span><span style="color: #88c0d0;">ls</span><span style="color: #d8dee9;"> -la</span><br>
+      <span style="color: #4c566a;">drwxr-xr-x</span> <span style="color: #81a1c1;">5</span> <span style="color: #ebcb8b;">user</span> <span style="color: #d8dee9;">staff</span> <span style="color: #b48ead;">160</span><br>
+      <span style="color: #bf616a;">error:</span> <span style="color: #d8dee9;">something went wrong</span><br>
+      <span style="color: #a3be8c;">~</span><span style="color: #d8dee9;"> $ </span><span style="color: #4c566a;">▌</span>
+    </div>
+    <div style="background: #3b4252; padding: 6px 10px; color: #d8dee9; font-size: 12px; font-weight: 500; border-top: 1px solid #434c5e;">
+      Nord
+    </div>
+  </div>
+
+  <!-- Catppuccin Mocha -->
+  <div style="border-radius: 8px; overflow: hidden; border: 1px solid #444; cursor: pointer;">
+    <div style="background: #1e1e2e; padding: 8px 10px; font-family: 'SF Mono', 'Menlo', monospace; font-size: 11px; line-height: 1.5;">
+      <span style="color: #a6e3a1;">~</span><span style="color: #cdd6f4;"> $ </span><span style="color: #94e2d5;">ls</span><span style="color: #cdd6f4;"> -la</span><br>
+      <span style="color: #585b70;">drwxr-xr-x</span> <span style="color: #89b4fa;">5</span> <span style="color: #f9e2af;">user</span> <span style="color: #cdd6f4;">staff</span> <span style="color: #f5c2e7;">160</span><br>
+      <span style="color: #f38ba8;">error:</span> <span style="color: #cdd6f4;">something went wrong</span><br>
+      <span style="color: #a6e3a1;">~</span><span style="color: #cdd6f4;"> $ </span><span style="color: #585b70;">▌</span>
+    </div>
+    <div style="background: #181825; padding: 6px 10px; color: #cdd6f4; font-size: 12px; font-weight: 500; border-top: 1px solid #313244;">
+      Catppuccin Mocha
+    </div>
+  </div>
+
+  <!-- Gruvbox Dark -->
+  <div style="border-radius: 8px; overflow: hidden; border: 1px solid #444; cursor: pointer;">
+    <div style="background: #282828; padding: 8px 10px; font-family: 'SF Mono', 'Menlo', monospace; font-size: 11px; line-height: 1.5;">
+      <span style="color: #98971a;">~</span><span style="color: #ebdbb2;"> $ </span><span style="color: #689d6a;">ls</span><span style="color: #ebdbb2;"> -la</span><br>
+      <span style="color: #504945;">drwxr-xr-x</span> <span style="color: #458588;">5</span> <span style="color: #d79921;">user</span> <span style="color: #ebdbb2;">staff</span> <span style="color: #b16286;">160</span><br>
+      <span style="color: #cc241d;">error:</span> <span style="color: #ebdbb2;">something went wrong</span><br>
+      <span style="color: #98971a;">~</span><span style="color: #ebdbb2;"> $ </span><span style="color: #504945;">▌</span>
+    </div>
+    <div style="background: #1d2021; padding: 6px 10px; color: #ebdbb2; font-size: 12px; font-weight: 500; border-top: 1px solid #3c3836;">
+      Gruvbox Dark
+    </div>
+  </div>
+
+  <!-- Rose Pine -->
+  <div style="border-radius: 8px; overflow: hidden; border: 1px solid #444; cursor: pointer;">
+    <div style="background: #191724; padding: 8px 10px; font-family: 'SF Mono', 'Menlo', monospace; font-size: 11px; line-height: 1.5;">
+      <span style="color: #31748f;">~</span><span style="color: #e0def4;"> $ </span><span style="color: #ebbcba;">ls</span><span style="color: #e0def4;"> -la</span><br>
+      <span style="color: #6e6a86;">drwxr-xr-x</span> <span style="color: #9ccfd8;">5</span> <span style="color: #f6c177;">user</span> <span style="color: #e0def4;">staff</span> <span style="color: #c4a7e7;">160</span><br>
+      <span style="color: #eb6f92;">error:</span> <span style="color: #e0def4;">something went wrong</span><br>
+      <span style="color: #31748f;">~</span><span style="color: #e0def4;"> $ </span><span style="color: #6e6a86;">▌</span>
+    </div>
+    <div style="background: #1f1d2e; padding: 6px 10px; color: #e0def4; font-size: 12px; font-weight: 500; border-top: 1px solid #26233a;">
+      Rose Pine
+    </div>
+  </div>
+
+  <!-- TokyoNight -->
+  <div style="border-radius: 8px; overflow: hidden; border: 1px solid #444; cursor: pointer;">
+    <div style="background: #1a1b26; padding: 8px 10px; font-family: 'SF Mono', 'Menlo', monospace; font-size: 11px; line-height: 1.5;">
+      <span style="color: #9ece6a;">~</span><span style="color: #c0caf5;"> $ </span><span style="color: #7dcfff;">ls</span><span style="color: #c0caf5;"> -la</span><br>
+      <span style="color: #565f89;">drwxr-xr-x</span> <span style="color: #7aa2f7;">5</span> <span style="color: #e0af68;">user</span> <span style="color: #c0caf5;">staff</span> <span style="color: #bb9af7;">160</span><br>
+      <span style="color: #f7768e;">error:</span> <span style="color: #c0caf5;">something went wrong</span><br>
+      <span style="color: #9ece6a;">~</span><span style="color: #c0caf5;"> $ </span><span style="color: #565f89;">▌</span>
+    </div>
+    <div style="background: #15161e; padding: 6px 10px; color: #c0caf5; font-size: 12px; font-weight: 500; border-top: 1px solid #292e42;">
+      TokyoNight
+    </div>
+  </div>
+
+</div>
+
+<p style="margin-top: 16px; color: #888; font-size: 13px;">This shows a 3-column layout. The actual picker would have a search bar at the top and scroll vertically through all 485 themes. Each card is clickable to select the theme.</p>

--- a/.superpowers/brainstorm/68424-1774250840/waiting.html
+++ b/.superpowers/brainstorm/68424-1774250840/waiting.html
@@ -1,0 +1,3 @@
+<div style="display:flex;align-items:center;justify-content:center;min-height:60vh">
+  <p class="subtitle">Continuing in terminal...</p>
+</div>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Run multiple sessions side by side in a single window with tabs, projects, and s
 - **Project sidebar**: Organize work by folder. Each project gets its own set of tabs, persisted across restarts.
 - **Context usage tracking**: A progress bar shows how much of Claude's context window the active session has consumed.
 - **Session state detection**: Tab badges show whether Claude is thinking, waiting for input, needs tool permission, or has errored. Terminal tabs show CPU/disk activity.
-- **Session persistence**: Claude sessions are saved across restarts. Relaunch Deckard and pick up where you left off.
+- **Session persistence**: Claude sessions resume via `--resume`. Terminal tabs preserve full shell state (scrollback, running processes, environment) across quit/relaunch using tmux when available.
 - **Terminal rendering**: Powered by [SwiftTerm](https://github.com/migueldeicaza/SwiftTerm), a self-contained terminal emulator with VT100/xterm emulation, IME support, and mouse reporting.
 
 ## Requirements

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -58,6 +58,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         log.log("startup", "Installing Claude Code hooks...")
         DeckardHooksInstaller.installIfNeeded()
 
+        // Clean up orphaned tmux sessions from previous runs
+        if TerminalSurface.tmuxAvailable {
+            let savedState = SessionManager.shared.load()
+            let activeSessions = Set(
+                (savedState?.projects ?? []).flatMap(\.tabs).compactMap(\.tmuxSessionName)
+            )
+            DispatchQueue.global(qos: .utility).async {
+                TerminalSurface.cleanupOrphanedTmuxSessions(activeSessions: activeSessions)
+            }
+            log.log("startup", "tmux available, \(activeSessions.count) saved sessions")
+        } else {
+            log.log("startup", "tmux not available")
+        }
+
         // Create and show the main window.
         log.log("startup", "Creating window controller...")
         windowController = DeckardWindowController()

--- a/Sources/Session/SessionState.swift
+++ b/Sources/Session/SessionState.swift
@@ -39,6 +39,7 @@ struct ProjectTabState: Codable {
     var name: String
     var isClaude: Bool
     var sessionId: String?
+    var tmuxSessionName: String?
 }
 
 /// Manages saving and loading Deckard state.

--- a/Sources/Terminal/TerminalSurface.swift
+++ b/Sources/Terminal/TerminalSurface.swift
@@ -11,10 +11,32 @@ class TerminalSurface: NSObject, LocalProcessTerminalViewDelegate {
     var pwd: String?
     var isAlive: Bool { !processExited }
     var onProcessExit: ((TerminalSurface) -> Void)?
+    /// The tmux session name, if this terminal is wrapped in tmux.
+    var tmuxSessionName: String?
 
     private let terminalView: LocalProcessTerminalView
     private var processExited = false
     private var pendingInitialInput: String?
+
+    // MARK: - tmux Detection
+
+    /// Whether tmux is available on this system (cached).
+    static let tmuxPath: String? = {
+        let candidates = ["/opt/homebrew/bin/tmux", "/usr/local/bin/tmux"]
+        for path in candidates {
+            if FileManager.default.isExecutableFile(atPath: path) { return path }
+        }
+        // Search PATH
+        if let pathEnv = ProcessInfo.processInfo.environment["PATH"] {
+            for dir in pathEnv.split(separator: ":") {
+                let full = "\(dir)/tmux"
+                if FileManager.default.isExecutableFile(atPath: full) { return full }
+            }
+        }
+        return nil
+    }()
+
+    static var tmuxAvailable: Bool { tmuxPath != nil }
 
     /// The NSView to add to the view hierarchy.
     var view: NSView { terminalView }
@@ -42,8 +64,11 @@ class TerminalSurface: NSObject, LocalProcessTerminalViewDelegate {
     }
 
     /// Start a shell process in the terminal.
+    /// - Parameter tmuxSession: If set, attach to this tmux session (resume). If nil and tmux is
+    ///   available and no initialInput (not a Claude tab), create a new tmux session.
     func startShell(workingDirectory: String? = nil, command: String? = nil,
-                    envVars: [String: String] = [:], initialInput: String? = nil) {
+                    envVars: [String: String] = [:], initialInput: String? = nil,
+                    tmuxSession: String? = nil) {
         let shell = command ?? ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
 
         // Build environment
@@ -56,22 +81,71 @@ class TerminalSurface: NSObject, LocalProcessTerminalViewDelegate {
 
         let envPairs = env.map { "\($0.key)=\($0.value)" }
 
-        terminalView.startProcess(
-            executable: shell,
-            args: ["-l"],
-            environment: envPairs,
-            execName: "-" + (shell as NSString).lastPathComponent,
-            currentDirectory: workingDirectory
-        )
+        // Decide whether to use tmux:
+        // - tmux must be available
+        // - No initialInput (Claude tabs use their own resume mechanism)
+        // - Either resuming an existing session or creating a new terminal tab
+        let tmuxSettingEnabled = UserDefaults.standard.object(forKey: "useTmux") as? Bool ?? true
+        let useTmux = Self.tmuxAvailable && tmuxSettingEnabled && initialInput == nil
+        let tmuxPath = Self.tmuxPath ?? "tmux"
 
-        // Register shell PID with ProcessMonitor directly
-        let pid = terminalView.process.shellPid
-        if pid > 0 {
-            ProcessMonitor.shared.registerShellPid(pid, forSurface: surfaceId.uuidString)
+        if useTmux {
+            let sessionName = tmuxSession ?? "deckard-\(surfaceId.uuidString.prefix(8))"
+            self.tmuxSessionName = sessionName
+
+            // tmux new-session -A: attach if exists, create if not
+            // -s: session name, -c: starting directory (only for new sessions)
+            var args = ["new-session", "-A", "-s", sessionName]
+            if let cwd = workingDirectory { args += ["-c", cwd] }
+
+            terminalView.startProcess(
+                executable: tmuxPath,
+                args: args,
+                environment: envPairs,
+                currentDirectory: workingDirectory
+            )
+
+            // Hide the tmux status bar after attaching. The -f config only
+            // applies on server start; this covers reattach to existing servers.
+            let tmux = tmuxPath
+            let session = sessionName
+            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.3) {
+                let task = Process()
+                task.executableURL = URL(fileURLWithPath: tmux)
+                task.arguments = ["set-option", "-t", session, "status", "off"]
+                task.standardOutput = FileHandle.nullDevice
+                task.standardError = FileHandle.nullDevice
+                try? task.run()
+            }
+        } else {
+            self.tmuxSessionName = nil
+            terminalView.startProcess(
+                executable: shell,
+                args: ["-l"],
+                environment: envPairs,
+                execName: "-" + (shell as NSString).lastPathComponent,
+                currentDirectory: workingDirectory
+            )
+        }
+
+        // Register shell PID with ProcessMonitor.
+        // For tmux sessions, the client PID isn't useful — query tmux for the
+        // actual shell PID inside the session after it starts.
+        let clientPid = terminalView.process.shellPid
+        if useTmux, let sessionName = self.tmuxSessionName {
+            let sid = surfaceId.uuidString
+            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.5) {
+                if let shellPid = Self.tmuxSessionPid(sessionName: sessionName) {
+                    ProcessMonitor.shared.registerShellPid(shellPid, forSurface: sid)
+                    DiagnosticLog.shared.log("surface", "tmux shell pid: \(shellPid) for session \(sessionName)")
+                }
+            }
+        } else if clientPid > 0 {
+            ProcessMonitor.shared.registerShellPid(clientPid, forSurface: surfaceId.uuidString)
         }
 
         DiagnosticLog.shared.log("surface",
-            "startShell: surfaceId=\(surfaceId) shell=\(shell) pid=\(pid) cwd=\(workingDirectory ?? "(nil)")")
+            "startShell: surfaceId=\(surfaceId) shell=\(shell) pid=\(clientPid) tmux=\(useTmux) cwd=\(workingDirectory ?? "(nil)")")
 
         // Send initial input after a short delay for shell readline to be ready
         if let initialInput {
@@ -90,10 +164,78 @@ class TerminalSurface: NSObject, LocalProcessTerminalViewDelegate {
     }
 
     /// Terminate the shell process.
+    /// When closing a tab, also kill the tmux session so it doesn't orphan.
+    /// On app quit, call `detach()` instead to keep the session alive.
     func terminate() {
         guard !processExited else { return }
         processExited = true
         terminalView.process?.terminate()
+        // Kill the tmux session when tab is explicitly closed
+        killTmuxSession()
+    }
+
+    /// Detach from the tmux session without killing it (for app quit).
+    func detach() {
+        guard !processExited else { return }
+        processExited = true
+        // Just kill the local process — tmux session survives
+        terminalView.process?.terminate()
+    }
+
+    private func killTmuxSession() {
+        guard let name = tmuxSessionName, let path = Self.tmuxPath else { return }
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: path)
+        task.arguments = ["kill-session", "-t", name]
+        task.standardOutput = FileHandle.nullDevice
+        task.standardError = FileHandle.nullDevice
+        try? task.run()
+    }
+
+    /// Get the shell PID running inside a tmux session.
+    private static func tmuxSessionPid(sessionName: String) -> pid_t? {
+        guard let path = tmuxPath else { return nil }
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: path)
+        task.arguments = ["list-panes", "-t", sessionName, "-F", "#{pane_pid}"]
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = FileHandle.nullDevice
+        try? task.run()
+        task.waitUntilExit()
+        let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        if let firstLine = output.split(separator: "\n").first, let pid = pid_t(firstLine) {
+            return pid
+        }
+        return nil
+    }
+
+    /// Clean up orphaned deckard tmux sessions that aren't in the saved state.
+    static func cleanupOrphanedTmuxSessions(activeSessions: Set<String>) {
+        guard let path = tmuxPath else { return }
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: path)
+        task.arguments = ["list-sessions", "-F", "#{session_name}"]
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = FileHandle.nullDevice
+        try? task.run()
+        task.waitUntilExit()
+
+        let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        for line in output.split(separator: "\n") {
+            let name = String(line)
+            if name.hasPrefix("deckard-") && !activeSessions.contains(name) {
+                let kill = Process()
+                kill.executableURL = URL(fileURLWithPath: path)
+                kill.arguments = ["kill-session", "-t", name]
+                kill.standardOutput = FileHandle.nullDevice
+                kill.standardError = FileHandle.nullDevice
+                try? kill.run()
+                kill.waitUntilExit()
+                DiagnosticLog.shared.log("tmux", "cleaned up orphaned session: \(name)")
+            }
+        }
     }
 
     // MARK: - Font

--- a/Sources/Window/DeckardWindowController.swift
+++ b/Sources/Window/DeckardWindowController.swift
@@ -412,7 +412,8 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
             project.name = snapshot.name
             for ts in snapshot.tabs {
                 createTabInProject(project, isClaude: ts.isClaude, name: ts.name,
-                                   sessionIdToResume: ts.isClaude ? ts.sessionId : nil)
+                                   sessionIdToResume: ts.isClaude ? ts.sessionId : nil,
+                                   tmuxSessionToResume: ts.tmuxSessionName)
             }
             project.selectedTabIndex = min(snapshot.selectedTabIndex, project.tabs.count - 1)
         }
@@ -511,7 +512,7 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
 
     // MARK: - Tab Management (within a project)
 
-    private func createTabInProject(_ project: ProjectItem, isClaude: Bool, name: String? = nil, sessionIdToResume: String? = nil) {
+    private func createTabInProject(_ project: ProjectItem, isClaude: Bool, name: String? = nil, sessionIdToResume: String? = nil, tmuxSessionToResume: String? = nil) {
         let surface = TerminalSurface()
         let tabName: String
         if let name = name {
@@ -557,7 +558,8 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
         surface.startShell(
             workingDirectory: project.path,
             envVars: envVars,
-            initialInput: initialInput
+            initialInput: initialInput,
+            tmuxSession: tmuxSessionToResume
         )
 
         surface.onProcessExit = { [weak self] exitedSurface in
@@ -984,7 +986,8 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
                         id: tab.id.uuidString,
                         name: tab.name,
                         isClaude: tab.isClaude,
-                        sessionId: tab.sessionId
+                        sessionId: tab.sessionId,
+                        tmuxSessionName: tab.surface.tmuxSessionName
                     )
                 }
             )
@@ -1024,7 +1027,8 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
                 if i == selectedIdx && t == selTab {
                     // Create the active tab's surface synchronously
                     createTabInProject(project, isClaude: ts.isClaude, name: ts.name,
-                                       sessionIdToResume: ts.isClaude ? ts.sessionId : nil)
+                                       sessionIdToResume: ts.isClaude ? ts.sessionId : nil,
+                                       tmuxSessionToResume: ts.tmuxSessionName)
                 } else {
                     pending.append((project: project, tab: ts, originalIndex: t))
                 }
@@ -1082,7 +1086,8 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
 
         // Create the tab (appends to project.tabs)
         createTabInProject(project, isClaude: ts.isClaude, name: ts.name,
-                           sessionIdToResume: ts.isClaude ? ts.sessionId : nil)
+                           sessionIdToResume: ts.isClaude ? ts.sessionId : nil,
+                           tmuxSessionToResume: ts.tmuxSessionName)
 
         // Move it from the end to its original position
         if insertAt < project.tabs.count - 1 {

--- a/Sources/Window/SettingsWindow.swift
+++ b/Sources/Window/SettingsWindow.swift
@@ -98,7 +98,7 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate {
         // fittingSize from expanding to the full content height (e.g., 485 theme cards).
         let preferredHeight: CGFloat = switch pane {
         case .theme: 580
-        case .terminal: 240
+        case .terminal: 280
         case .general: 160
         case .shortcuts: 340
         case .about: 200
@@ -468,6 +468,17 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate {
         scrollUnit.translatesAutoresizingMaskIntoConstraints = false
         pane.addSubview(scrollUnit)
 
+        // tmux session persistence toggle
+        let tmuxEnabled = UserDefaults.standard.object(forKey: "useTmux") as? Bool ?? true
+        let tmuxCheckbox = NSButton(checkboxWithTitle: "Use tmux for session persistence (if installed)", target: self, action: #selector(tmuxToggleChanged(_:)))
+        tmuxCheckbox.state = tmuxEnabled ? .on : .off
+        tmuxCheckbox.translatesAutoresizingMaskIntoConstraints = false
+        if !TerminalSurface.tmuxAvailable {
+            tmuxCheckbox.isEnabled = false
+            tmuxCheckbox.title = "Use tmux for session persistence (tmux not found)"
+        }
+        pane.addSubview(tmuxCheckbox)
+
         NSLayoutConstraint.activate([
             fontLabel.topAnchor.constraint(equalTo: pane.topAnchor, constant: 20),
             fontLabel.leadingAnchor.constraint(equalTo: pane.leadingAnchor, constant: 20),
@@ -505,7 +516,9 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate {
             scrollUnit.centerYAnchor.constraint(equalTo: scrollLabel.centerYAnchor),
             scrollUnit.leadingAnchor.constraint(equalTo: scrollField.trailingAnchor, constant: 4),
 
-            scrollLabel.bottomAnchor.constraint(equalTo: pane.bottomAnchor, constant: -20),
+            tmuxCheckbox.topAnchor.constraint(equalTo: scrollLabel.bottomAnchor, constant: 16),
+            tmuxCheckbox.leadingAnchor.constraint(equalTo: pane.leadingAnchor, constant: 20),
+            tmuxCheckbox.bottomAnchor.constraint(equalTo: pane.bottomAnchor, constant: -20),
         ])
 
         return pane
@@ -540,6 +553,12 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate {
         // Notify terminals to update font
         NotificationCenter.default.post(name: .deckardFontChanged, object: nil,
                                         userInfo: ["font": font])
+    }
+
+    // MARK: - tmux Settings
+
+    @objc private func tmuxToggleChanged(_ sender: NSButton) {
+        UserDefaults.standard.set(sender.state == .on, forKey: "useTmux")
     }
 
     // MARK: - Scrollback Settings

--- a/docs/superpowers/plans/2026-03-22-test-suite.md
+++ b/docs/superpowers/plans/2026-03-22-test-suite.md
@@ -1,0 +1,848 @@
+# Test Suite Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a comprehensive XCTest suite covering every source file in Deckard, and run it in CI.
+
+**Architecture:** One test file per source module. Tests use `@testable import Deckard` to access internal APIs. Fixture files for theme/session/JSONL parsing tests. CI runs `xcodebuild test`.
+
+**Tech Stack:** XCTest, Swift, `@testable import Deckard`
+
+**Spec:** `docs/superpowers/specs/2026-03-22-test-suite-design.md`
+
+---
+
+### Task 1: Set up test target and CI
+
+**Files:**
+- Modify: `Deckard.xcodeproj/project.pbxproj` — add DeckardTests target
+- Create: `Tests/DeckardTests.swift` — minimal test to verify setup
+- Modify: `.github/workflows/ci.yml` — add test job
+
+- [ ] **Step 1: Add XCTest target to Xcode project**
+
+The easiest way is via Xcode GUI (File > New > Target > Unit Testing Bundle > "DeckardTests"). Alternatively, edit the pbxproj to add a test target that links to the main Deckard target with `TEST_HOST` set.
+
+- [ ] **Step 2: Create a minimal test file**
+
+Create `Tests/DeckardTests.swift`:
+```swift
+import XCTest
+@testable import Deckard
+
+final class SmokeTests: XCTestCase {
+    func testAppLaunches() {
+        // If this test runs, the test target links correctly
+        XCTAssertTrue(true)
+    }
+}
+```
+
+- [ ] **Step 3: Create fixture directory**
+
+```bash
+mkdir -p Tests/Fixtures
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+xcodebuild test -project Deckard.xcodeproj -scheme Deckard -destination 'platform=macOS' 2>&1 | tail -20
+```
+
+- [ ] **Step 5: Add test job to CI**
+
+Add to `.github/workflows/ci.yml`:
+```yaml
+  test:
+    name: Test
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Xcode 26
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app
+      - name: Resolve SPM dependencies
+        run: xcodebuild -resolvePackageDependencies -project Deckard.xcodeproj
+      - name: Run tests
+        run: |
+          xcodebuild test \
+            -project Deckard.xcodeproj \
+            -scheme Deckard \
+            -destination 'platform=macOS'
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "chore: add XCTest target and CI test job"
+```
+
+---
+
+### Task 2: ThemeColors tests
+
+**Files:**
+- Create: `Tests/ThemeColorsTests.swift`
+
+- [ ] **Step 1: Write tests**
+
+```swift
+import XCTest
+@testable import Deckard
+
+final class ThemeColorsTests: XCTestCase {
+
+    // MARK: - Dark mode detection
+
+    func testDarkBackgroundIsDark() {
+        let colors = ThemeColors(
+            background: NSColor(red: 0.1, green: 0.1, blue: 0.1, alpha: 1),
+            foreground: NSColor.white
+        )
+        XCTAssertTrue(colors.isDark)
+    }
+
+    func testLightBackgroundIsNotDark() {
+        let colors = ThemeColors(
+            background: NSColor(red: 0.9, green: 0.9, blue: 0.9, alpha: 1),
+            foreground: NSColor.black
+        )
+        XCTAssertFalse(colors.isDark)
+    }
+
+    func testBoundaryLuminance() {
+        // Luminance exactly 0.5 should be light (> check)
+        let mid = NSColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1)
+        let colors = ThemeColors(background: mid, foreground: NSColor.white)
+        // luminance of (0.5, 0.5, 0.5) = 0.299*0.5 + 0.587*0.5 + 0.114*0.5 = 0.5
+        XCTAssertFalse(colors.isDark) // 0.5 <= 0.5 → isDark = true
+        // Actually: 0.5 <= 0.5 is true, so isDark = true
+        // Let's just verify the behavior is consistent
+    }
+
+    // MARK: - Derived colors for dark mode
+
+    func testDarkModeSidebarIsBrighterThanBackground() {
+        let bg = NSColor(red: 0.1, green: 0.1, blue: 0.1, alpha: 1)
+        let colors = ThemeColors(background: bg, foreground: NSColor.white)
+        XCTAssertTrue(colors.isDark)
+        // Sidebar should be slightly brighter than background
+        XCTAssertGreaterThan(colors.sidebarBackground.luminance, bg.luminance)
+    }
+
+    func testDarkModeTextColorsMatchForeground() {
+        let fg = NSColor(red: 0.9, green: 0.8, blue: 0.7, alpha: 1)
+        let colors = ThemeColors(
+            background: NSColor(red: 0.1, green: 0.1, blue: 0.1, alpha: 1),
+            foreground: fg
+        )
+        XCTAssertEqual(colors.primaryText, fg)
+    }
+
+    // MARK: - Derived colors for light mode
+
+    func testLightModeUsesSystemColors() {
+        let colors = ThemeColors(
+            background: NSColor(red: 1, green: 1, blue: 1, alpha: 1),
+            foreground: NSColor.black
+        )
+        XCTAssertFalse(colors.isDark)
+        XCTAssertEqual(colors.primaryText, .labelColor)
+        XCTAssertEqual(colors.secondaryText, .secondaryLabelColor)
+    }
+
+    // MARK: - Default
+
+    func testDefaultIsNotNil() {
+        let d = ThemeColors.default
+        XCTAssertNotNil(d.background)
+        XCTAssertNotNil(d.foreground)
+    }
+
+    // MARK: - NSColor extensions
+
+    func testLuminanceBlack() {
+        let black = NSColor(red: 0, green: 0, blue: 0, alpha: 1)
+        XCTAssertEqual(black.luminance, 0, accuracy: 0.001)
+    }
+
+    func testLuminanceWhite() {
+        let white = NSColor(red: 1, green: 1, blue: 1, alpha: 1)
+        XCTAssertEqual(white.luminance, 1, accuracy: 0.001)
+    }
+
+    func testLuminanceRed() {
+        let red = NSColor(red: 1, green: 0, blue: 0, alpha: 1)
+        XCTAssertEqual(red.luminance, 0.299, accuracy: 0.001)
+    }
+
+    func testAdjustedBrightnessUp() {
+        let mid = NSColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1)
+        let brighter = mid.adjustedBrightness(by: 0.1)
+        XCTAssertGreaterThan(brighter.luminance, mid.luminance)
+    }
+
+    func testAdjustedBrightnessClampsToOne() {
+        let bright = NSColor(red: 1, green: 1, blue: 1, alpha: 1)
+        let result = bright.adjustedBrightness(by: 0.5)
+        // Should not exceed 1.0 brightness
+        XCTAssertLessThanOrEqual(result.luminance, 1.0)
+    }
+
+    func testAdjustedBrightnessClampsToZero() {
+        let dark = NSColor(red: 0, green: 0, blue: 0, alpha: 1)
+        let result = dark.adjustedBrightness(by: -0.5)
+        XCTAssertGreaterThanOrEqual(result.luminance, 0.0)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+xcodebuild test -project Deckard.xcodeproj -scheme Deckard -destination 'platform=macOS' -only-testing:DeckardTests/ThemeColorsTests 2>&1 | grep -E "Test Case|passed|failed"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Tests/ThemeColorsTests.swift
+git commit -m "test: add ThemeColors tests"
+```
+
+---
+
+### Task 3: TerminalColorScheme tests
+
+**Files:**
+- Create: `Tests/TerminalColorSchemeTests.swift`
+- Create: `Tests/Fixtures/Dracula.theme`
+- Create: `Tests/Fixtures/minimal.theme`
+- Create: `Tests/Fixtures/missing-bg.theme`
+
+- [ ] **Step 1: Create fixture files**
+
+`Tests/Fixtures/Dracula.theme`:
+```
+palette = 0=#21222c
+palette = 1=#ff5555
+palette = 2=#50fa7b
+palette = 3=#f1fa8c
+palette = 4=#bd93f9
+palette = 5=#ff79c6
+palette = 6=#8be9fd
+palette = 7=#f8f8f2
+palette = 8=#6272a4
+palette = 9=#ff6e6e
+palette = 10=#69ff94
+palette = 11=#ffffa5
+palette = 12=#d6acff
+palette = 13=#ff92df
+palette = 14=#a4ffff
+palette = 15=#ffffff
+background = #282a36
+foreground = #f8f8f2
+cursor-color = #f8f8f2
+cursor-text = #282a36
+selection-background = #44475a
+selection-foreground = #ffffff
+```
+
+`Tests/Fixtures/minimal.theme`:
+```
+background = #000000
+foreground = #ffffff
+```
+
+`Tests/Fixtures/missing-bg.theme`:
+```
+foreground = #ffffff
+palette = 0=#000000
+```
+
+- [ ] **Step 2: Write tests**
+
+```swift
+import XCTest
+@testable import Deckard
+
+final class TerminalColorSchemeTests: XCTestCase {
+
+    private func fixturePath(_ name: String) -> String {
+        Bundle(for: type(of: self)).resourcePath! + "/" + name
+    }
+
+    // MARK: - Hex Parsing
+
+    func testParseHexWithHash() {
+        let scheme = TerminalColorScheme.parse(from: fixturePath("Dracula.theme"))
+        XCTAssertNotNil(scheme)
+    }
+
+    // MARK: - Full theme parsing
+
+    func testParseDraculaTheme() {
+        let scheme = TerminalColorScheme.parse(from: fixturePath("Dracula.theme"))!
+        // Background #282a36
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        scheme.background.usingColorSpace(.sRGB)!.getRed(&r, green: &g, blue: &b, alpha: &a)
+        XCTAssertEqual(r, 0x28 / 255.0, accuracy: 0.01)
+        XCTAssertEqual(g, 0x2a / 255.0, accuracy: 0.01)
+        XCTAssertEqual(b, 0x36 / 255.0, accuracy: 0.01)
+    }
+
+    func testParseDraculaPalette() {
+        let scheme = TerminalColorScheme.parse(from: fixturePath("Dracula.theme"))!
+        XCTAssertEqual(scheme.palette.count, 16)
+    }
+
+    func testParseDraculaCursorColor() {
+        let scheme = TerminalColorScheme.parse(from: fixturePath("Dracula.theme"))!
+        XCTAssertNotNil(scheme.cursorColor)
+        XCTAssertNotNil(scheme.cursorTextColor)
+    }
+
+    func testParseDraculaSelectionBackground() {
+        let scheme = TerminalColorScheme.parse(from: fixturePath("Dracula.theme"))!
+        XCTAssertNotNil(scheme.selectionBackground)
+    }
+
+    // MARK: - Minimal theme
+
+    func testParseMinimalTheme() {
+        let scheme = TerminalColorScheme.parse(from: fixturePath("minimal.theme"))!
+        XCTAssertNotNil(scheme.background)
+        XCTAssertNotNil(scheme.foreground)
+        // Should fill missing palette with defaults
+        XCTAssertEqual(scheme.palette.count, 16)
+        XCTAssertNil(scheme.cursorColor)
+    }
+
+    // MARK: - Missing required fields
+
+    func testParseMissingBackgroundReturnsNil() {
+        let scheme = TerminalColorScheme.parse(from: fixturePath("missing-bg.theme"))
+        XCTAssertNil(scheme)
+    }
+
+    // MARK: - Nonexistent file
+
+    func testParseNonexistentFileReturnsNil() {
+        let scheme = TerminalColorScheme.parse(from: "/nonexistent/path")
+        XCTAssertNil(scheme)
+    }
+
+    // MARK: - Comments and blank lines
+
+    func testParseIgnoresComments() {
+        let tmp = NSTemporaryDirectory() + "comment-test.theme"
+        try! """
+        # This is a comment
+        background = #000000
+
+        foreground = #ffffff
+        # Another comment
+        """.write(toFile: tmp, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let scheme = TerminalColorScheme.parse(from: tmp)
+        XCTAssertNotNil(scheme)
+    }
+
+    // MARK: - Default scheme
+
+    func testDefaultScheme() {
+        let d = TerminalColorScheme.default
+        XCTAssertNotNil(d.background)
+        XCTAssertNotNil(d.foreground)
+        XCTAssertTrue(d.palette.isEmpty) // Default has no palette
+    }
+
+    // MARK: - Selection foreground ignored
+
+    func testSelectionForegroundIgnored() {
+        let scheme = TerminalColorScheme.parse(from: fixturePath("Dracula.theme"))!
+        // selection-foreground is in the file but SwiftTerm doesn't support it
+        // The scheme should still parse successfully
+        XCTAssertNotNil(scheme)
+    }
+}
+```
+
+Note: Fixture files need to be added to the test target's Copy Bundle Resources phase so `Bundle(for:).resourcePath` finds them.
+
+- [ ] **Step 3: Run and commit**
+
+---
+
+### Task 4: SessionState tests
+
+**Files:**
+- Create: `Tests/SessionStateTests.swift`
+
+- [ ] **Step 1: Write tests**
+
+```swift
+import XCTest
+@testable import Deckard
+
+final class SessionStateTests: XCTestCase {
+
+    // MARK: - Codable roundtrips
+
+    func testDeckardStateRoundtrip() throws {
+        let state = DeckardState(projects: [
+            ProjectState(id: "p1", path: "/tmp/test", name: "test",
+                        selectedTabIndex: 0, tabs: [
+                            ProjectTabState(id: "t1", name: "Claude #1", isClaude: true, sessionId: "sess1")
+                        ])
+        ])
+        let data = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(DeckardState.self, from: data)
+        XCTAssertEqual(decoded.projects?.count, 1)
+        XCTAssertEqual(decoded.projects?.first?.tabs.count, 1)
+        XCTAssertEqual(decoded.projects?.first?.tabs.first?.sessionId, "sess1")
+    }
+
+    func testTabStateRoundtrip() throws {
+        let tab = ProjectTabState(id: "t1", name: "Terminal #1", isClaude: false, sessionId: nil)
+        let data = try JSONEncoder().encode(tab)
+        let decoded = try JSONDecoder().decode(ProjectTabState.self, from: data)
+        XCTAssertEqual(decoded.name, "Terminal #1")
+        XCTAssertFalse(decoded.isClaude)
+        XCTAssertNil(decoded.sessionId)
+    }
+
+    func testEmptyStateRoundtrip() throws {
+        let state = DeckardState()
+        let data = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(DeckardState.self, from: data)
+        XCTAssertEqual(decoded.version, 2)
+    }
+
+    func testMultipleProjectsRoundtrip() throws {
+        let state = DeckardState(
+            selectedTabIndex: 1,
+            projects: [
+                ProjectState(id: "p1", path: "/a", name: "A", selectedTabIndex: 0, tabs: []),
+                ProjectState(id: "p2", path: "/b", name: "B", selectedTabIndex: 2, tabs: [
+                    ProjectTabState(id: "t1", name: "C1", isClaude: true, sessionId: nil),
+                    ProjectTabState(id: "t2", name: "C2", isClaude: true, sessionId: "s2"),
+                    ProjectTabState(id: "t3", name: "T1", isClaude: false, sessionId: nil),
+                ])
+            ]
+        )
+        let data = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(DeckardState.self, from: data)
+        XCTAssertEqual(decoded.selectedTabIndex, 1)
+        XCTAssertEqual(decoded.projects?.count, 2)
+        XCTAssertEqual(decoded.projects?[1].tabs.count, 3)
+    }
+
+    // MARK: - SessionManager file I/O
+
+    func testSaveAndLoad() throws {
+        let manager = SessionManager.shared
+        let state = DeckardState(projects: [
+            ProjectState(id: "p1", path: "/test", name: "Test", selectedTabIndex: 0, tabs: [])
+        ])
+        manager.save(state)
+        let loaded = manager.load()
+        XCTAssertNotNil(loaded)
+        XCTAssertEqual(loaded?.projects?.first?.path, "/test")
+    }
+
+    func testLoadMissingFileReturnsNil() {
+        // Remove the state file if it exists
+        let path = NSHomeDirectory() + "/Library/Application Support/Deckard/state.json"
+        let backup = path + ".backup"
+        let fm = FileManager.default
+        if fm.fileExists(atPath: path) {
+            try? fm.moveItem(atPath: path, toPath: backup)
+        }
+        defer {
+            if fm.fileExists(atPath: backup) {
+                try? fm.moveItem(atPath: backup, toPath: path)
+            }
+        }
+        try? fm.removeItem(atPath: path)
+        let loaded = SessionManager.shared.load()
+        XCTAssertNil(loaded)
+    }
+}
+```
+
+- [ ] **Step 2: Run and commit**
+
+---
+
+### Task 5: ThemeManager tests
+
+**Files:**
+- Create: `Tests/ThemeManagerTests.swift`
+
+- [ ] **Step 1: Write tests**
+
+```swift
+import XCTest
+@testable import Deckard
+
+final class ThemeManagerTests: XCTestCase {
+
+    func testLoadAvailableThemesFindsThemes() {
+        let manager = ThemeManager.shared
+        manager.loadAvailableThemes()
+        // Bundled themes from Resources/themes/
+        XCTAssertGreaterThan(manager.availableThemes.count, 100)
+    }
+
+    func testThemesAreSortedAlphabetically() {
+        let manager = ThemeManager.shared
+        manager.loadAvailableThemes()
+        let names = manager.availableThemes.map(\.name)
+        XCTAssertEqual(names, names.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending })
+    }
+
+    func testLoadSkipsLicenseFiles() {
+        let manager = ThemeManager.shared
+        manager.loadAvailableThemes()
+        let names = manager.availableThemes.map(\.name)
+        XCTAssertFalse(names.contains(where: { $0.hasPrefix("LICENSE") }))
+    }
+
+    func testLoadSkipsDotfiles() {
+        let manager = ThemeManager.shared
+        manager.loadAvailableThemes()
+        let names = manager.availableThemes.map(\.name)
+        XCTAssertFalse(names.contains(where: { $0.hasPrefix(".") }))
+    }
+
+    func testApplyThemeWithValidName() {
+        let manager = ThemeManager.shared
+        manager.loadAvailableThemes()
+        guard let theme = manager.availableThemes.first(where: { $0.name == "Dracula" }) else {
+            XCTSkip("Dracula theme not bundled")
+            return
+        }
+        manager.applyTheme(name: theme.name)
+        XCTAssertEqual(manager.currentThemeName, "Dracula")
+        XCTAssertNotNil(manager.currentScheme.cursorColor)
+    }
+
+    func testApplyThemeWithNilRevertsToDefault() {
+        let manager = ThemeManager.shared
+        manager.loadAvailableThemes()
+        manager.applyTheme(name: "Dracula")
+        manager.applyTheme(name: nil)
+        XCTAssertNil(manager.currentThemeName)
+    }
+
+    func testApplyThemePostsNotification() {
+        let manager = ThemeManager.shared
+        manager.loadAvailableThemes()
+
+        let expectation = expectation(forNotification: .deckardThemeChanged, object: nil)
+        manager.applyTheme(name: manager.availableThemes.first?.name)
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testApplyUnknownThemeRevertsToDefault() {
+        let manager = ThemeManager.shared
+        manager.loadAvailableThemes()
+        manager.applyTheme(name: "NonexistentTheme12345")
+        XCTAssertNil(manager.currentThemeName)
+    }
+}
+```
+
+- [ ] **Step 2: Run and commit**
+
+---
+
+### Task 6: ControlSocket message tests
+
+**Files:**
+- Create: `Tests/ControlMessageTests.swift`
+
+- [ ] **Step 1: Write tests**
+
+```swift
+import XCTest
+@testable import Deckard
+
+final class ControlMessageTests: XCTestCase {
+
+    func testDecodeRegisterPid() throws {
+        let json = """
+        {"command":"register-pid","surfaceId":"ABC-123","pid":42}
+        """.data(using: .utf8)!
+        let msg = try JSONDecoder().decode(ControlMessage.self, from: json)
+        XCTAssertEqual(msg.command, "register-pid")
+        XCTAssertEqual(msg.surfaceId, "ABC-123")
+        XCTAssertEqual(msg.pid, 42)
+    }
+
+    func testDecodeListTabs() throws {
+        let json = """
+        {"command":"list-tabs"}
+        """.data(using: .utf8)!
+        let msg = try JSONDecoder().decode(ControlMessage.self, from: json)
+        XCTAssertEqual(msg.command, "list-tabs")
+        XCTAssertNil(msg.surfaceId)
+    }
+
+    func testDecodeUpdateBadge() throws {
+        let json = """
+        {"command":"hook.stop","surfaceId":"ABC"}
+        """.data(using: .utf8)!
+        let msg = try JSONDecoder().decode(ControlMessage.self, from: json)
+        XCTAssertEqual(msg.command, "hook.stop")
+    }
+
+    func testDecodeRenameTab() throws {
+        let json = """
+        {"command":"rename-tab","tabId":"T1","name":"My Tab"}
+        """.data(using: .utf8)!
+        let msg = try JSONDecoder().decode(ControlMessage.self, from: json)
+        XCTAssertEqual(msg.tabId, "T1")
+        XCTAssertEqual(msg.name, "My Tab")
+    }
+
+    func testDecodeWithAllOptionalsMissing() throws {
+        let json = """
+        {"command":"ping"}
+        """.data(using: .utf8)!
+        let msg = try JSONDecoder().decode(ControlMessage.self, from: json)
+        XCTAssertEqual(msg.command, "ping")
+        XCTAssertNil(msg.surfaceId)
+        XCTAssertNil(msg.sessionId)
+        XCTAssertNil(msg.pid)
+        XCTAssertNil(msg.tabId)
+        XCTAssertNil(msg.name)
+    }
+
+    // MARK: - ControlResponse encoding
+
+    func testEncodeResponseOk() throws {
+        let resp = ControlResponse(ok: true)
+        let data = try JSONEncoder().encode(resp)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertEqual(json["ok"] as? Bool, true)
+    }
+
+    func testEncodeResponseWithTabs() throws {
+        let tab = TabInfo(id: "t1", name: "Claude #1", isClaude: true, isMaster: false,
+                         sessionId: "s1", badgeState: "thinking", workingDirectory: "/tmp")
+        let resp = ControlResponse(ok: true, tabs: [tab])
+        let data = try JSONEncoder().encode(resp)
+        let decoded = try JSONDecoder().decode(ControlResponse.self, from: data)
+        XCTAssertEqual(decoded.tabs?.count, 1)
+        XCTAssertEqual(decoded.tabs?.first?.name, "Claude #1")
+        XCTAssertEqual(decoded.tabs?.first?.badgeState, "thinking")
+    }
+
+    func testResponseRoundtrip() throws {
+        let resp = ControlResponse(ok: true, error: nil, message: "pong", tabs: nil)
+        let data = try JSONEncoder().encode(resp)
+        let decoded = try JSONDecoder().decode(ControlResponse.self, from: data)
+        XCTAssertEqual(decoded.ok, true)
+        XCTAssertEqual(decoded.message, "pong")
+    }
+}
+```
+
+- [ ] **Step 2: Run and commit**
+
+---
+
+### Task 7: DiagnosticLog tests
+
+**Files:**
+- Create: `Tests/DiagnosticLogTests.swift`
+
+- [ ] **Step 1: Write tests**
+
+```swift
+import XCTest
+@testable import Deckard
+
+final class DiagnosticLogTests: XCTestCase {
+
+    func testLogWritesToFile() {
+        let log = DiagnosticLog.shared
+        let marker = "TEST-\(UUID().uuidString)"
+        log.log("test", marker)
+
+        // Wait for async write
+        let expectation = expectation(description: "log written")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { expectation.fulfill() }
+        wait(for: [expectation], timeout: 2.0)
+
+        let content = try? String(contentsOf: log.fileURL, encoding: .utf8)
+        XCTAssertTrue(content?.contains(marker) ?? false, "Log should contain the test marker")
+    }
+
+    func testLogFormatIncludesCategory() {
+        let log = DiagnosticLog.shared
+        let marker = "CATTEST-\(UUID().uuidString)"
+        log.log("mycat", marker)
+
+        let expectation = expectation(description: "log written")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { expectation.fulfill() }
+        wait(for: [expectation], timeout: 2.0)
+
+        let content = try? String(contentsOf: log.fileURL, encoding: .utf8)
+        XCTAssertTrue(content?.contains("[mycat]") ?? false)
+    }
+
+    func testLogFormatIncludesBuildTag() {
+        let log = DiagnosticLog.shared
+        let marker = "BUILDTEST-\(UUID().uuidString)"
+        log.log("test", marker)
+
+        let expectation = expectation(description: "log written")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { expectation.fulfill() }
+        wait(for: [expectation], timeout: 2.0)
+
+        let content = try? String(contentsOf: log.fileURL, encoding: .utf8)
+        // Build tag format: [vX.Y.Z(B)-MMdd-HHmm]
+        XCTAssertTrue(content?.contains("[v") ?? false)
+    }
+}
+```
+
+- [ ] **Step 2: Run and commit**
+
+---
+
+### Task 8: HookHandler, DeckardHooksInstaller, CrashReporter, ContextMonitor, ProcessMonitor tests
+
+These are grouped because they each need small test files that follow similar patterns.
+
+**Files:**
+- Create: `Tests/HookHandlerTests.swift`
+- Create: `Tests/DeckardHooksInstallerTests.swift`
+- Create: `Tests/CrashReporterTests.swift`
+- Create: `Tests/ContextMonitorTests.swift`
+- Create: `Tests/ProcessMonitorTests.swift`
+- Create: `Tests/TerminalSurfaceTests.swift`
+- Create: `Tests/Fixtures/session.jsonl`
+
+- [ ] **Step 1: Create session fixture**
+
+`Tests/Fixtures/session.jsonl` — a sample Claude session file:
+```json
+{"type":"system","message":"Starting session"}
+{"type":"assistant","message":"Hello","usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":0,"cache_read_input_tokens":200},"model":"claude-sonnet-4-20250514"}
+```
+
+- [ ] **Step 2: Write all test files**
+
+See the spec for the full list of test cases. Each file tests one source module. Key tests:
+
+**HookHandlerTests.swift** — test message routing for each command type using a mock that records calls.
+
+**DeckardHooksInstallerTests.swift** — test hook script content contains expected markers, JSON merge logic with temp files.
+
+**CrashReporterTests.swift** — test crash report path computation, previous crash detection with temp files.
+
+**ContextMonitorTests.swift** — test JSONL parsing with fixture, percentage calculation, model limits.
+
+**ProcessMonitorTests.swift** — test `ActivityInfo.isActive` logic, `registerShellPid` stores mapping.
+
+**TerminalSurfaceTests.swift** — test env var construction, `isAlive` state, double-terminate safety.
+
+- [ ] **Step 3: Run all tests**
+
+```bash
+xcodebuild test -project Deckard.xcodeproj -scheme Deckard -destination 'platform=macOS' 2>&1 | grep -E "Test Case|passed|failed|error:"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Tests/
+git commit -m "test: add comprehensive test suite for all modules"
+```
+
+---
+
+### Task 9: DeckardWindowController data logic tests
+
+**Files:**
+- Create: `Tests/WindowControllerLogicTests.swift`
+
+- [ ] **Step 1: Write tests**
+
+Tests for data logic that can be exercised through the public/internal API without requiring window creation:
+
+```swift
+import XCTest
+@testable import Deckard
+
+final class WindowControllerLogicTests: XCTestCase {
+
+    // MARK: - TabItem
+
+    func testTabItemInitSetsId() {
+        let surface = TerminalSurface()
+        let tab = TabItem(surface: surface, name: "Test", isClaude: true)
+        XCTAssertEqual(tab.id, surface.surfaceId)
+        XCTAssertEqual(tab.name, "Test")
+        XCTAssertTrue(tab.isClaude)
+    }
+
+    func testTabItemBadgeStateDefault() {
+        let surface = TerminalSurface()
+        let tab = TabItem(surface: surface, name: "Test", isClaude: false)
+        XCTAssertEqual(tab.badgeState, .none)
+    }
+
+    // MARK: - Badge state
+
+    func testBadgeStateRawValues() {
+        XCTAssertEqual(TabItem.BadgeState.thinking.rawValue, "thinking")
+        XCTAssertEqual(TabItem.BadgeState.waitingForInput.rawValue, "waitingForInput")
+        XCTAssertEqual(TabItem.BadgeState.error.rawValue, "error")
+        XCTAssertEqual(TabItem.BadgeState.idle.rawValue, "idle")
+    }
+
+    // MARK: - ProcessMonitor ActivityInfo
+
+    func testActivityInfoIsActive() {
+        let active = ProcessMonitor.ActivityInfo(cpu: true, disk: false)
+        XCTAssertTrue(active.isActive)
+
+        let diskOnly = ProcessMonitor.ActivityInfo(cpu: false, disk: true)
+        XCTAssertTrue(diskOnly.isActive)
+
+        let idle = ProcessMonitor.ActivityInfo(cpu: false, disk: false)
+        XCTAssertFalse(idle.isActive)
+    }
+}
+```
+
+- [ ] **Step 2: Run and commit**
+
+---
+
+### Task 10: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+xcodebuild test -project Deckard.xcodeproj -scheme Deckard -destination 'platform=macOS' 2>&1 | grep -E "Test Suite|passed|failed"
+```
+
+- [ ] **Step 2: Verify CI workflow**
+
+Push and check that the test job runs on GitHub Actions.
+
+- [ ] **Step 3: Final commit**
+
+```bash
+git add -A
+git commit -m "test: finalize test suite and CI integration"
+git push origin master
+```


### PR DESCRIPTION
## Summary

- Terminal tabs are transparently wrapped in named tmux sessions when tmux is installed
- On quit, tmux sessions survive. On relaunch, Deckard reattaches — full shell state preserved (scrollback, processes, env vars)
- Progressive enhancement: falls back to fresh shells when tmux isn't available
- Configurable toggle in Settings > Terminal (on by default)
- Orphaned tmux sessions cleaned up on startup
- Claude tabs unaffected (they use `--resume`)

## Test plan

- [ ] Install tmux (`brew install tmux`), open terminal tab, run commands, quit and relaunch — verify state preserved
- [ ] Close a tab explicitly — verify tmux session is killed (not orphaned)
- [ ] Disable the setting in Settings > Terminal — verify new tabs spawn fresh shells
- [ ] Uninstall tmux — verify terminal tabs work normally (fresh shell, no errors)
- [ ] Verify Claude tabs still use `--resume` (not tmux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)