### PR TITLE
fix: prevent context usage bar from flickering

### DIFF
--- a/Sources/Window/DeckardWindowController.swift
+++ b/Sources/Window/DeckardWindowController.swift
@@ -725,6 +725,7 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
         DispatchQueue.global(qos: .utility).async {
             let usage = ContextMonitor.shared.getUsage(sessionId: sessionId, projectPath: projectPath)
             DispatchQueue.main.async { [weak self] in
+                guard let usage = usage else { return }
                 self?.applyContextUsage(usage)
             }
         }


### PR DESCRIPTION
## Summary
- When the periodic background read of the session JSONL returns `nil` (transient file contention with Claude Code), skip the UI update instead of collapsing the bar to zero width
- Preserves the last known context usage value during transient read failures

## Test plan
- [ ] Build and launch Deckard
- [ ] Open a Claude tab, start a conversation, observe the context bar stays visible without flickering

🤖 Generated with [Claude Code](https://claude.com/claude-code)