### PR TITLE
feat: collapsible sidebar folders for organizing projects

### DIFF
--- a/Deckard.xcodeproj/project.pbxproj
+++ b/Deckard.xcodeproj/project.pbxproj
@@ -33,6 +33,10 @@
 		DD220001DD220001DD220001 /* ProcessMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD220002DD220002DD220002 /* ProcessMonitor.swift */; };
 		DD330001DD330001DD330001 /* DiagnosticLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD330002DD330002DD330002 /* DiagnosticLog.swift */; };
 		DD440001DD440001DD440001 /* CrashReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD440002DD440002DD440002 /* CrashReporter.swift */; };
+		SC000001SC000001SC000001 /* SidebarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = SC000002SC000002SC000002 /* SidebarController.swift */; };
+		TB000001TB000001TB000001 /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = TB000002TB000002TB000002 /* TabBarController.swift */; };
+		SV000001SV000001SV000001 /* SidebarViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = SV000002SV000002SV000002 /* SidebarViews.swift */; };
+		TV000001TV000001TV000001 /* TabBarViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = TV000002TV000002TV000002 /* TabBarViews.swift */; };
 		AA110001AA110001AA110001 /* ThemeColorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA110002AA110002AA110002 /* ThemeColorsTests.swift */; };
 		AA120001AA120001AA120001 /* TerminalColorSchemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA120002AA120002AA120002 /* TerminalColorSchemeTests.swift */; };
 		AA130001AA130001AA130001 /* SessionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA130002AA130002AA130002 /* SessionStateTests.swift */; };
@@ -74,6 +78,10 @@
 		DD220002DD220002DD220002 /* ProcessMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessMonitor.swift; sourceTree = "<group>"; };
 		DD330002DD330002DD330002 /* DiagnosticLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticLog.swift; sourceTree = "<group>"; };
 		DD440002DD440002DD440002 /* CrashReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReporter.swift; sourceTree = "<group>"; };
+		SC000002SC000002SC000002 /* SidebarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarController.swift; sourceTree = "<group>"; };
+		TB000002TB000002TB000002 /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
+		SV000002SV000002SV000002 /* SidebarViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarViews.swift; sourceTree = "<group>"; };
+		TV000002TV000002TV000002 /* TabBarViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarViews.swift; sourceTree = "<group>"; };
 		ST000005ST000005ST000005 /* TerminalSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSurface.swift; sourceTree = "<group>"; };
 		TE000001TE000001TE000001 /* SmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmokeTests.swift; sourceTree = "<group>"; };
 		TE000004TE000004TE000004 /* DeckardTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DeckardTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -170,6 +178,10 @@
 			isa = PBXGroup;
 			children = (
 				8391EFB62A21AFA1DA62733F /* DeckardWindowController.swift */,
+				SC000002SC000002SC000002 /* SidebarController.swift */,
+				TB000002TB000002TB000002 /* TabBarController.swift */,
+				SV000002SV000002SV000002 /* SidebarViews.swift */,
+				TV000002TV000002TV000002 /* TabBarViews.swift */,
 				4BE07F0C0F9D62925EF195F7 /* ProjectPicker.swift */,
 				DD37F7C8CC5243DCF0A1346E /* SettingsWindow.swift */,
 				TC100002TC100002TC100002 /* ThemeCardView.swift */,
@@ -363,6 +375,10 @@
 				2E4FF6C3438B5F0E73C4FA87 /* ContextMonitor.swift in Sources */,
 				7E500DC8ECF3F7D073A098A4 /* ControlSocket.swift in Sources */,
 				37FA9D946FD6ECA1DDF5898A /* DeckardWindowController.swift in Sources */,
+				SC000001SC000001SC000001 /* SidebarController.swift in Sources */,
+				TB000001TB000001TB000001 /* TabBarController.swift in Sources */,
+				SV000001SV000001SV000001 /* SidebarViews.swift in Sources */,
+				TV000001TV000001TV000001 /* TabBarViews.swift in Sources */,
 				A0FF9B9E99BC8B33FDCAB7E5 /* HookHandler.swift in Sources */,
 				70265FBBA52FB6E60AE4EFFE /* ProjectPicker.swift in Sources */,
 				2D322E22D0679FD39D688539 /* SessionState.swift in Sources */,

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -156,6 +156,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         closeItem.setShortcut(for: .closeTab)
         fileMenu.addItem(closeItem)
 
+        let newFolderItem = NSMenuItem(title: "New Sidebar Folder", action: #selector(createNewSidebarFolder), keyEquivalent: "")
+        newFolderItem.target = self
+        fileMenu.addItem(newFolderItem)
+
         let closeProjectItem = NSMenuItem(title: "Close Folder", action: #selector(closeCurrentProject), keyEquivalent: "")
         closeProjectItem.setShortcut(for: .closeFolder)
         fileMenu.addItem(closeProjectItem)
@@ -263,6 +267,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func selectTabByNumber(_ sender: NSMenuItem) {
         windowController?.selectProject(byNumber: sender.tag)
+    }
+
+    @objc private func createNewSidebarFolder() {
+        windowController?.createSidebarFolder()
     }
 
     @objc private func toggleSidebar() {

--- a/Sources/Session/SessionState.swift
+++ b/Sources/Session/SessionState.swift
@@ -14,6 +14,10 @@ struct DeckardState: Codable {
 
     // v2: project-based
     var projects: [ProjectState]?
+
+    // v3: sidebar folders
+    var sidebarFolders: [SidebarFolderState]?
+    var sidebarOrder: [SidebarOrderItem]?
 }
 
 struct TabState: Codable {
@@ -40,6 +44,50 @@ struct ProjectTabState: Codable {
     var isClaude: Bool
     var sessionId: String?
     var tmuxSessionName: String?
+}
+
+struct SidebarFolderState: Codable {
+    var id: String
+    var name: String
+    var isCollapsed: Bool
+    var projectIds: [String]
+}
+
+/// A tagged union for sidebar ordering — either a folder or an ungrouped project.
+enum SidebarOrderItem: Codable {
+    case folder(String)   // folder id
+    case project(String)  // project id
+
+    private enum CodingKeys: String, CodingKey {
+        case type, id
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .folder(let id):
+            try container.encode("folder", forKey: .type)
+            try container.encode(id, forKey: .id)
+        case .project(let id):
+            try container.encode("project", forKey: .type)
+            try container.encode(id, forKey: .id)
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        let id = try container.decode(String.self, forKey: .id)
+        switch type {
+        case "folder":
+            self = .folder(id)
+        case "project":
+            self = .project(id)
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .type, in: container,
+                debugDescription: "Unknown sidebar order item type: \(type)")
+        }
+    }
 }
 
 /// Manages saving and loading Deckard state.

--- a/Sources/Window/DeckardWindowController.swift
+++ b/Sources/Window/DeckardWindowController.swift
@@ -56,6 +56,36 @@ class ProjectItem {
     }
 }
 
+// MARK: - Sidebar Folder Model
+
+/// A folder in the sidebar that groups projects.
+class SidebarFolder {
+    let id: UUID
+    var name: String
+    var isCollapsed: Bool
+    var projectIds: [UUID]  // references to ProjectItem.id
+
+    init(name: String) {
+        self.id = UUID()
+        self.name = name
+        self.isCollapsed = false
+        self.projectIds = []
+    }
+
+    init(id: UUID, name: String, isCollapsed: Bool, projectIds: [UUID]) {
+        self.id = id
+        self.name = name
+        self.isCollapsed = isCollapsed
+        self.projectIds = projectIds
+    }
+}
+
+/// Ordered sidebar items: either a folder or an ungrouped project reference.
+enum SidebarItem {
+    case folder(SidebarFolder)
+    case project(UUID)  // ProjectItem.id
+}
+
 // MARK: - Default Tab Configuration
 
 struct DefaultTabConfig {
@@ -78,6 +108,8 @@ struct DefaultTabConfig {
 // MARK: - Window Controller
 
 let deckardProjectDragType = NSPasteboard.PasteboardType("com.deckard.project-reorder")
+let deckardSidebarDragType = NSPasteboard.PasteboardType("com.deckard.sidebar-drag")
+let deckardFolderDragType = NSPasteboard.PasteboardType("com.deckard.folder-reorder")
 
 
 private class CollapsibleSplitView: NSSplitView {
@@ -91,8 +123,12 @@ private class CollapsibleSplitView: NSSplitView {
 }
 
 class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
-    private var projects: [ProjectItem] = []
-    private var selectedProjectIndex: Int = -1
+    var projects: [ProjectItem] = []
+    var selectedProjectIndex: Int = -1
+
+    // Sidebar folders
+    var sidebarFolders: [SidebarFolder] = []
+    var sidebarOrder: [SidebarItem] = []
 
     // Theme
     private var colors: ThemeColors { ThemeManager.shared.currentColors }
@@ -100,32 +136,37 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
     // UI
     private let splitView = CollapsibleSplitView()
     private let sidebarView = NSView()
-    private let sidebarStackView = ReorderableStackView()
+    let sidebarStackView = ReorderableStackView()
     private let rightPane = NSView()
-    private let tabBar = ReorderableHStackView()  // horizontal tab bar
-    private var isRebuildingTabBar = false
-    private var needsTabBarRebuild = false
+    let tabBar = ReorderableHStackView()  // horizontal tab bar
+    var isRebuildingTabBar = false
+    var needsTabBarRebuild = false
     /// Saved first responder before a rebuild, used to detect and restore focus theft.
-    private weak var savedFirstResponder: NSResponder?
+    weak var savedFirstResponder: NSResponder?
     private let terminalContainerView = NSView()
     private let contextProgressBar = NSView()
     private var contextProgressFill = NSView()
     private var contextTimer: Timer?
     private var processMonitorTimer: Timer?
-    private var currentTerminalView: NSView?
+    var currentTerminalView: NSView?
     /// Opaque overlay shown when a project has no tabs, covering any surfaces underneath.
     private var emptyStateView: NSView?
 
-    private let sidebarDropZone = SidebarDropZone()
+    let sidebarDropZone = SidebarDropZone()
     private let openFolderButton = NSButton()
     private let sidebarWidth: CGFloat = 210
     private var sidebarInitialized = false
     private var sidebarWidthBeforeCollapse: CGFloat = 210
     /// Recently closed projects — stored so reopening the same path restores tabs.
     private var recentlyClosedProjects: [ProjectState] = []
-    private var isRestoring = false
+    var isRestoring = false
     /// Tabs in the order they were created (for ProcessMonitor PID matching).
-    private var tabCreationOrder: [UUID] = []
+    var tabCreationOrder: [UUID] = []
+
+    /// Last activity info per surface, used for tooltips.
+    var terminalActivity: [UUID: ProcessMonitor.ActivityInfo] = [:]
+    /// Consecutive active poll count per surface — require 2 before showing as active.
+    private var terminalActiveStreak: [UUID: Int] = [:]
 
     init() {
         let window = NSWindow(
@@ -222,7 +263,7 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
 
         // Drop zone covers the entire sidebar area below the stack
         sidebarDropZone.translatesAutoresizingMaskIntoConstraints = false
-        sidebarDropZone.registerForDraggedTypes([deckardProjectDragType])
+        sidebarDropZone.registerForDraggedTypes([deckardProjectDragType, deckardFolderDragType])
         sidebarView.addSubview(sidebarDropZone)
 
         sidebarStackView.orientation = .vertical
@@ -427,6 +468,7 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
         }
 
         projects.append(project)
+        sidebarOrder.append(.project(project.id))
         rebuildSidebar()
         selectProject(at: projects.count - 1)
         if !isRestoring { saveState() }
@@ -470,6 +512,7 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
         }
 
         projects.remove(at: index)
+        removeSidebarReference(projectId: project.id)
         rebuildSidebar()
 
         if projects.isEmpty {
@@ -488,6 +531,12 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
         selectedProjectIndex = index
 
         let project = projects[index]
+
+        // Auto-expand folder if the selected project is inside a collapsed one
+        for folder in sidebarFolders where folder.isCollapsed && folder.projectIds.contains(project.id) {
+            folder.isCollapsed = false
+            rebuildSidebar()
+        }
 
         rebuildTabBar()
 
@@ -512,7 +561,7 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
 
     // MARK: - Tab Management (within a project)
 
-    private func createTabInProject(_ project: ProjectItem, isClaude: Bool, name: String? = nil, sessionIdToResume: String? = nil, tmuxSessionToResume: String? = nil) {
+    func createTabInProject(_ project: ProjectItem, isClaude: Bool, name: String? = nil, sessionIdToResume: String? = nil, tmuxSessionToResume: String? = nil) {
         let surface = TerminalSurface()
         let tabName: String
         if let name = name {
@@ -573,7 +622,7 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
     }
 
     /// Guards against rapid duplicate tab creation from key repeat.
-    private var isCreatingTab = false
+    var isCreatingTab = false
 
     func addTabToCurrentProject(isClaude: Bool) {
         guard !isCreatingTab else { return }
@@ -656,7 +705,7 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
         return projects[selectedProjectIndex]
     }
 
-    private func showTab(_ tab: TabItem) {
+    func showTab(_ tab: TabItem) {
         hideEmptyState()
 
         let view = tab.surface.view
@@ -689,7 +738,7 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
     }
 
     /// Show the empty-state overlay (project has no tabs).
-    private func showEmptyState() {
+    func showEmptyState() {
         currentTerminalView?.removeFromSuperview()
         emptyStateView?.isHidden = false
     }
@@ -782,11 +831,6 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
         }
     }
 
-    /// Last activity info per surface, used for tooltips.
-    private var terminalActivity: [UUID: ProcessMonitor.ActivityInfo] = [:]
-    /// Consecutive active poll count per surface — require 2 before showing as active.
-    private var terminalActiveStreak: [UUID: Int] = [:]
-
     private func applyTerminalBadgeStates(_ states: [UUID: ProcessMonitor.ActivityInfo]) {
         var changed = false
         for project in projects {
@@ -805,7 +849,7 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
                 if tab.badgeState != newBadge {
                     if newBadge == .terminalActive {
                         DiagnosticLog.shared.log("processmon",
-                            "badge → terminalActive: project=\(project.path) tab=\"\(tab.name)\"")
+                            "badge -> terminalActive: project=\(project.path) tab=\"\(tab.name)\"")
                     }
                     tab.badgeState = newBadge
                     changed = true
@@ -993,6 +1037,27 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
                 }
             )
         }
+
+        // Persist sidebar folders
+        state.sidebarFolders = sidebarFolders.map { folder in
+            SidebarFolderState(
+                id: folder.id.uuidString,
+                name: folder.name,
+                isCollapsed: folder.isCollapsed,
+                projectIds: folder.projectIds.map { $0.uuidString }
+            )
+        }
+
+        // Persist sidebar order
+        state.sidebarOrder = sidebarOrder.compactMap { item in
+            switch item {
+            case .folder(let folder):
+                return .folder(folder.id.uuidString)
+            case .project(let pid):
+                return .project(pid.uuidString)
+            }
+        }
+
         return state
     }
 
@@ -1042,6 +1107,9 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
         // Keep isRestoring = true until Phase 2 finishes, so selectProject
         // won't clamp selectedTabIndex before all tabs are inserted.
 
+        // Restore sidebar folders
+        restoreSidebarFolders(from: state)
+
         rebuildSidebar()
         if selectedIdx >= 0 && selectedIdx < projects.count {
             selectProject(at: selectedIdx)
@@ -1049,6 +1117,52 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
 
         // Phase 2: Create remaining surfaces progressively with small delays for UX.
         createTabsProgressively(pending)
+    }
+
+    private func restoreSidebarFolders(from state: DeckardState) {
+        // During restore, ProjectItem gets a new UUID. Build a map from saved-id -> live ProjectItem.
+        guard let projectStates = state.projects else { return }
+        var savedIdToProject: [String: ProjectItem] = [:]
+        for ps in projectStates {
+            if let project = projects.first(where: { $0.path == ps.path }) {
+                savedIdToProject[ps.id] = project
+            }
+        }
+
+        // Restore folders
+        if let folderStates = state.sidebarFolders {
+            for fs in folderStates {
+                guard let folderId = UUID(uuidString: fs.id) else { continue }
+                let resolvedIds = fs.projectIds.compactMap { savedIdToProject[$0]?.id }
+                let folder = SidebarFolder(
+                    id: folderId,
+                    name: fs.name,
+                    isCollapsed: fs.isCollapsed,
+                    projectIds: resolvedIds
+                )
+                sidebarFolders.append(folder)
+            }
+        }
+
+        // Restore sidebar order
+        if let orderItems = state.sidebarOrder {
+            sidebarOrder = orderItems.compactMap { item in
+                switch item {
+                case .folder(let idStr):
+                    if let folder = sidebarFolders.first(where: { $0.id.uuidString == idStr }) {
+                        return .folder(folder)
+                    }
+                    return nil
+                case .project(let idStr):
+                    if let project = savedIdToProject[idStr] {
+                        return .project(project.id)
+                    }
+                    return nil
+                }
+            }
+        }
+
+        // If no saved order, ensureSidebarOrder() will build one from projects
     }
 
     private func createTabsProgressively(_ remaining: [(project: ProjectItem, tab: ProjectTabState, originalIndex: Int)]) {
@@ -1065,7 +1179,7 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
                 self?.captureState() ?? DeckardState()
             }
 
-            // Dump tab creation order → PID mapping for diagnostics
+            // Dump tab creation order -> PID mapping for diagnostics
             let mapping = tabCreationOrder.enumerated().map { (i, id) -> String in
                 var label = "?"
                 for project in projects {
@@ -1102,152 +1216,7 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
         }
     }
 
-    // MARK: - Sidebar (project list)
-
-    func rebuildSidebar() {
-        let savedFR = window?.firstResponder
-        defer {
-            if let terminal = currentTerminalView, savedFR === terminal,
-               window?.firstResponder !== terminal {
-                DiagnosticLog.shared.log("sidebar",
-                    "rebuildSidebar: focus stolen! restoring terminal view")
-                window?.makeFirstResponder(terminal)
-            }
-        }
-        sidebarStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
-
-        for (i, project) in projects.enumerated() {
-            let row = VerticalTabRowView(title: project.name, bold: false, index: i,
-                                 target: self, action: #selector(projectRowClicked(_:)))
-            row.badgeInfos = project.tabs.filter { $0.badgeState != .none }.map { tab in
-                (state: tab.badgeState, name: tab.name, activity: self.terminalActivity[tab.id])
-            }
-            row.onRename = { [weak self] newName in
-                guard let self = self, i < self.projects.count else { return }
-                self.projects[i].name = newName
-                self.saveState()
-            }
-            row.onClearName = { [weak self] in
-                guard let self = self, i < self.projects.count else { return }
-                let defaultName = (self.projects[i].path as NSString).lastPathComponent
-                self.projects[i].name = defaultName
-                self.rebuildSidebar()
-                self.saveState()
-            }
-            row.onReorder = { [weak self] fromIndex, toIndex in
-                self?.reorderProject(from: fromIndex, to: toIndex)
-            }
-            row.onContextMenu = { [weak self] event in
-                guard let self = self, i < self.projects.count else { return nil }
-                return self.buildProjectContextMenu(for: self.projects[i])
-            }
-            sidebarStackView.addArrangedSubview(row)
-            row.leadingAnchor.constraint(equalTo: sidebarStackView.leadingAnchor).isActive = true
-            row.trailingAnchor.constraint(equalTo: sidebarStackView.trailingAnchor).isActive = true
-        }
-
-        sidebarStackView.registerForDraggedTypes([deckardProjectDragType])
-        sidebarStackView.onReorder = { [weak self] from, to in
-            self?.reorderProject(from: from, to: to)
-        }
-        sidebarDropZone.onDrop = { [weak self] fromIndex in
-            guard let self = self else { return }
-            self.reorderProject(from: fromIndex, to: self.projects.count)
-        }
-        sidebarDropZone.sidebarStackView = sidebarStackView
-
-        updateSidebarSelection()
-    }
-
-    private func reorderProject(from fromIndex: Int, to toIndex: Int) {
-        guard fromIndex != toIndex,
-              fromIndex >= 0, fromIndex < projects.count,
-              toIndex >= 0, toIndex <= projects.count else { return }
-
-        let project = projects.remove(at: fromIndex)
-        let insertAt = toIndex > fromIndex ? toIndex - 1 : toIndex
-        projects.insert(project, at: min(insertAt, projects.count))
-
-        // Update selected index
-        if selectedProjectIndex == fromIndex {
-            selectedProjectIndex = insertAt
-        } else if fromIndex < selectedProjectIndex && insertAt >= selectedProjectIndex {
-            selectedProjectIndex -= 1
-        } else if fromIndex > selectedProjectIndex && insertAt <= selectedProjectIndex {
-            selectedProjectIndex += 1
-        }
-
-        rebuildSidebar()
-        saveState()
-    }
-
-    // MARK: - Project Context Menu
-
-    private class ResumeSessionInfo {
-        let project: ProjectItem
-        let sessionId: String
-        let tabName: String?
-        init(project: ProjectItem, sessionId: String, tabName: String?) {
-            self.project = project
-            self.sessionId = sessionId
-            self.tabName = tabName
-        }
-    }
-
-    private func buildProjectContextMenu(for project: ProjectItem) -> NSMenu {
-        let menu = NSMenu()
-
-        let resumeItem = NSMenuItem(title: "Resume Session", action: nil, keyEquivalent: "")
-        let resumeSubmenu = NSMenu()
-
-        let sessions = ContextMonitor.shared.listSessions(forProjectPath: project.path)
-        let openSessionIds = Set(project.tabs.compactMap { $0.sessionId })
-        let resumable = sessions.filter { !openSessionIds.contains($0.sessionId) }
-
-        if resumable.isEmpty {
-            let emptyItem = NSMenuItem(title: "No sessions to resume", action: nil, keyEquivalent: "")
-            emptyItem.isEnabled = false
-            resumeSubmenu.addItem(emptyItem)
-        } else {
-            let savedNames = SessionManager.shared.loadSessionNames()
-            let formatter = RelativeDateTimeFormatter()
-            formatter.unitsStyle = .abbreviated
-
-            for session in resumable.prefix(50) {
-                let timeStr = formatter.localizedString(for: session.modificationDate, relativeTo: Date())
-                let savedName = savedNames[session.sessionId]
-
-                let title: String
-                if let name = savedName, !name.isEmpty {
-                    title = "\(timeStr) \u{2014} \(name)"
-                } else if !session.firstUserMessage.isEmpty {
-                    let msg = session.firstUserMessage.count > 60
-                        ? String(session.firstUserMessage.prefix(60)) + "\u{2026}"
-                        : session.firstUserMessage
-                    title = "\(timeStr) \u{2014} \(msg)"
-                } else {
-                    title = timeStr
-                }
-
-                let item = NSMenuItem(title: title, action: #selector(resumeSessionMenuAction(_:)), keyEquivalent: "")
-                item.target = self
-                item.representedObject = ResumeSessionInfo(project: project, sessionId: session.sessionId, tabName: savedName)
-                resumeSubmenu.addItem(item)
-            }
-        }
-
-        resumeItem.submenu = resumeSubmenu
-        menu.addItem(resumeItem)
-
-        menu.addItem(.separator())
-
-        let closeItem = NSMenuItem(title: "Close Folder", action: #selector(closeProjectMenuAction(_:)), keyEquivalent: "")
-        closeItem.target = self
-        closeItem.representedObject = project
-        menu.addItem(closeItem)
-
-        return menu
-    }
+    // MARK: - Theme
 
     @objc private func themeDidChange(_ notification: Notification) {
         guard let scheme = notification.userInfo?["scheme"] as? TerminalColorScheme else { return }
@@ -1271,194 +1240,6 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
         }
     }
 
-    @objc private func closeProjectMenuAction(_ sender: NSMenuItem) {
-        guard let project = sender.representedObject as? ProjectItem,
-              let pi = projects.firstIndex(where: { $0.id == project.id }) else { return }
-        closeProject(at: pi)
-    }
-
-    @objc private func resumeSessionMenuAction(_ sender: NSMenuItem) {
-        guard let info = sender.representedObject as? ResumeSessionInfo else { return }
-        let project = info.project
-        let sessionId = info.sessionId
-
-        createTabInProject(project, isClaude: true, name: info.tabName, sessionIdToResume: sessionId)
-        project.selectedTabIndex = project.tabs.count - 1
-
-        if let pi = projects.firstIndex(where: { $0.id == project.id }) {
-            if pi == selectedProjectIndex {
-                rebuildTabBar()
-                showTab(project.tabs[project.selectedTabIndex])
-            } else {
-                selectProject(at: pi)
-            }
-        }
-        saveState()
-    }
-
-    private func updateSidebarSelection() {
-        for (i, view) in sidebarStackView.arrangedSubviews.enumerated() {
-            if let row = view as? VerticalTabRowView {
-                row.isSelected = (i == selectedProjectIndex)
-            }
-        }
-    }
-
-    @objc private func openProjectClicked() {
-        AppDelegate.shared?.openProjectPicker()
-    }
-
-    @objc private func projectRowClicked(_ sender: VerticalTabRowView) {
-        selectProject(at: sender.index)
-    }
-
-    // MARK: - Tab Bar (horizontal tabs within selected project)
-
-    private var isTabEditing: Bool {
-        tabBar.arrangedSubviews.contains { ($0 as? HorizontalTabView)?.isEditing == true }
-    }
-
-    func rebuildTabBar() {
-        guard !isRebuildingTabBar else { return }
-        if isTabEditing {
-            needsTabBarRebuild = true
-            return
-        }
-        isRebuildingTabBar = true
-        defer {
-            isRebuildingTabBar = false
-            // Restore focus if the rebuild stole it from the terminal
-            if let terminal = currentTerminalView, savedFirstResponder === terminal,
-               window?.firstResponder !== terminal {
-                DiagnosticLog.shared.log("tabbar",
-                    "rebuildTabBar: focus stolen! restoring terminal view")
-                window?.makeFirstResponder(terminal)
-            }
-            savedFirstResponder = nil
-        }
-        savedFirstResponder = window?.firstResponder
-
-        tabBar.arrangedSubviews.forEach { $0.removeFromSuperview() }
-        guard let project = currentProject else { return }
-
-        for (i, tab) in project.tabs.enumerated() {
-            let isSelected = (i == project.selectedTabIndex)
-            let title = " \(tab.name) "
-
-            let tabView = HorizontalTabView(
-                displayTitle: title,
-                editableName: tab.name,
-                isClaude: tab.isClaude,
-                badgeState: tab.badgeState,
-                activity: terminalActivity[tab.id],
-                isSelected: isSelected,
-                index: i,
-                target: self,
-                clickAction: #selector(tabBarClicked(_:))
-            )
-            tabView.onRename = { [weak self] newName in
-                guard let self = self, let project = self.currentProject,
-                      i < project.tabs.count else { return }
-                let tab = project.tabs[i]
-                tab.name = newName
-                if let sid = tab.sessionId, !sid.isEmpty {
-                    SessionManager.shared.saveSessionName(sessionId: sid, name: newName)
-                }
-                self.rebuildTabBar()
-                self.saveState()
-            }
-            tabView.onClearName = { [weak self] in
-                guard let self = self, let project = self.currentProject,
-                      i < project.tabs.count else { return }
-                let tab = project.tabs[i]
-                let base = tab.isClaude ? "Claude" : "Terminal"
-                let sameType = project.tabs.filter { $0.isClaude == tab.isClaude }
-                tab.name = sameType.count <= 1 ? base : "\(base) #\(i + 1)"
-                self.rebuildTabBar()
-                self.saveState()
-            }
-            tabView.onEditingFinished = { [weak self] in
-                guard let self = self, self.needsTabBarRebuild else { return }
-                self.needsTabBarRebuild = false
-                self.rebuildTabBar()
-            }
-            tabBar.addArrangedSubview(tabView)
-        }
-
-        // Set up drag-to-reorder
-        tabBar.tabCount = project.tabs.count
-        tabBar.registerForDraggedTypes([deckardTabDragType])
-        tabBar.onReorder = { [weak self] from, to in
-            self?.reorderTab(from: from, to: to)
-        }
-
-        // Add "+" button
-        let addButton = AddTabButton(
-            leftClickAction: { [weak self] in self?.addTabToCurrentProject(isClaude: true) },
-            rightClickAction: { [weak self] in self?.addTabToCurrentProject(isClaude: false) }
-        )
-        tabBar.addArrangedSubview(addButton)
-
-        // Spacer
-        let spacer = NSView()
-        spacer.translatesAutoresizingMaskIntoConstraints = false
-        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        tabBar.addArrangedSubview(spacer)
-    }
-
-    private func reorderTab(from fromIndex: Int, to toIndex: Int) {
-        guard let project = currentProject else { return }
-        guard fromIndex != toIndex,
-              fromIndex >= 0, fromIndex < project.tabs.count,
-              toIndex >= 0, toIndex <= project.tabs.count else { return }
-
-        let tab = project.tabs.remove(at: fromIndex)
-        let insertAt = toIndex > fromIndex ? toIndex - 1 : toIndex
-        project.tabs.insert(tab, at: min(insertAt, project.tabs.count))
-
-        if project.selectedTabIndex == fromIndex {
-            project.selectedTabIndex = insertAt
-        } else if fromIndex < project.selectedTabIndex && insertAt >= project.selectedTabIndex {
-            project.selectedTabIndex -= 1
-        } else if fromIndex > project.selectedTabIndex && insertAt <= project.selectedTabIndex {
-            project.selectedTabIndex += 1
-        }
-
-        rebuildTabBar()
-        rebuildSidebar()
-        saveState()
-    }
-
-    @objc private func tabBarClicked(_ sender: HorizontalTabView) {
-        selectTabInProject(at: sender.index)
-    }
-
-    @objc private func tabBarCloseClicked(_ sender: NSButton) {
-        guard let project = currentProject else { return }
-        let idx = sender.tag
-        guard idx >= 0, idx < project.tabs.count else { return }
-
-        let tab = project.tabs[idx]
-        tab.surface.terminate()
-        tabCreationOrder.removeAll { $0 == tab.id }
-
-        project.tabs.remove(at: idx)
-
-        if project.tabs.isEmpty {
-            currentTerminalView = nil
-            showEmptyState()
-            rebuildTabBar()
-            rebuildSidebar()
-        } else {
-            project.selectedTabIndex = min(idx, project.tabs.count - 1)
-            rebuildTabBar()
-            rebuildSidebar()
-            showTab(project.tabs[project.selectedTabIndex])
-        }
-        saveState()
-    }
-
-
     // MARK: - Navigation
 
     func selectNextProject() {
@@ -1478,697 +1259,15 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
     }
 }
 
-// MARK: - VerticalTabRowView
-
-class VerticalTabRowView: NSView, NSTextFieldDelegate, NSDraggingSource {
-    var title: String {
-        didSet { label.stringValue = title }
-    }
-    var isSelected: Bool = false {
-        didSet { needsDisplay = true }
-    }
-    /// Badge info for each Claude tab in this project, shown as right-aligned dots.
-    var badgeInfos: [(state: TabItem.BadgeState, name: String, activity: ProcessMonitor.ActivityInfo?)] = [] {
-        didSet { updateBadgeDots() }
-    }
-    var onRename: ((String) -> Void)?
-    var onClearName: (() -> Void)?
-    var onReorder: ((Int, Int) -> Void)?
-    var onContextMenu: ((NSEvent) -> NSMenu?)?
-    let index: Int
-    private let label: NSTextField
-    private let badgeContainer: NSStackView
-    private weak var target: AnyObject?
-    private let action: Selector
-    private var dragStartPoint: NSPoint?
-
-    init(title: String, bold: Bool, index: Int, target: AnyObject, action: Selector) {
-        self.title = title
-        self.index = index
-        self.target = target
-        self.action = action
-
-        label = NSTextField(labelWithString: title)
-        label.font = bold ? .boldSystemFont(ofSize: 12) : .systemFont(ofSize: 12)
-        label.textColor = ThemeManager.shared.currentColors.primaryText
-        label.lineBreakMode = .byTruncatingTail
-        label.maximumNumberOfLines = 1
-
-        badgeContainer = NSStackView()
-        badgeContainer.orientation = .horizontal
-        badgeContainer.spacing = 3
-        badgeContainer.setContentHuggingPriority(.required, for: .horizontal)
-
-        super.init(frame: .zero)
-        translatesAutoresizingMaskIntoConstraints = false
-        wantsLayer = true
-
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.toolTip = shortcutTooltip("Close Folder", for: .closeFolder)
-        badgeContainer.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(label)
-        addSubview(badgeContainer)
-
-        NSLayoutConstraint.activate([
-            heightAnchor.constraint(equalToConstant: 28),
-            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
-            label.centerYAnchor.constraint(equalTo: centerYAnchor),
-            label.trailingAnchor.constraint(lessThanOrEqualTo: badgeContainer.leadingAnchor, constant: -4),
-            badgeContainer.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
-            badgeContainer.centerYAnchor.constraint(equalTo: centerYAnchor),
-        ])
-    }
-
-    required init?(coder: NSCoder) { fatalError() }
-
-    override func draw(_ dirtyRect: NSRect) {
-        if isSelected {
-            ThemeManager.shared.currentColors.selectedBackground.setFill()
-            bounds.fill()
-        }
-    }
-
-
-    private func updateBadgeDots() {
-        badgeContainer.arrangedSubviews.forEach {
-            $0.layer?.removeAllAnimations()
-            $0.removeFromSuperview()
-        }
-        for info in badgeInfos where info.state != .none {
-            let dot = NSView()
-            dot.wantsLayer = true
-            dot.layer?.cornerRadius = 3.5
-            dot.layer?.backgroundColor = Self.colorForBadge(info.state).cgColor
-            dot.toolTip = "\(info.name): \(Self.tooltipForBadge(info.state, activity: info.activity))"
-            dot.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                dot.widthAnchor.constraint(equalToConstant: 7),
-                dot.heightAnchor.constraint(equalToConstant: 7),
-            ])
-            if SettingsWindowController.isBadgeAnimated(info.state) {
-                Self.addPulseAnimation(to: dot)
-            }
-            badgeContainer.addArrangedSubview(dot)
-        }
-    }
-
-    static func addPulseAnimation(to view: NSView) {
-        guard let layer = view.layer else { return }
-        let anim = CABasicAnimation(keyPath: "opacity")
-        anim.fromValue = 1.0
-        anim.toValue = 0.3
-        anim.duration = 1.2
-        anim.autoreverses = true
-        anim.repeatCount = .infinity
-        anim.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-        layer.add(anim, forKey: "pulse")
-    }
-
-    static func tooltipForBadge(_ state: TabItem.BadgeState, activity: ProcessMonitor.ActivityInfo? = nil) -> String {
-        switch state {
-        case .none: return ""
-        case .idle: return "Idle"
-        case .thinking: return "Thinking..."
-        case .waitingForInput: return "Waiting for input"
-        case .needsPermission: return "Needs permission"
-        case .error: return "Error"
-        case .terminalIdle: return "Idle"
-        case .terminalActive: return activity?.description ?? "Running"
-        case .terminalError: return "Error"
-        }
-    }
-
-    static let defaultBadgeColors: [TabItem.BadgeState: NSColor] = [
-        .idle: .systemGray,
-        .thinking: NSColor(red: 0.85, green: 0.65, blue: 0.2, alpha: 1.0),
-        .waitingForInput: NSColor(red: 0.65, green: 0.4, blue: 0.9, alpha: 1.0),
-        .needsPermission: .systemOrange,
-        .error: .systemRed,
-        .terminalIdle: NSColor(red: 0.35, green: 0.55, blue: 0.54, alpha: 1.0),
-        .terminalActive: NSColor(red: 0.45, green: 0.72, blue: 0.71, alpha: 1.0),
-        .terminalError: NSColor(red: 0.85, green: 0.3, blue: 0.3, alpha: 1.0),
-    ]
-
-    static func colorForBadge(_ state: TabItem.BadgeState) -> NSColor {
-        if state == .none { return .clear }
-        if let hex = UserDefaults.standard.string(forKey: "badgeColor.\(state.rawValue)"),
-           let color = NSColor.fromHex(hex) {
-            return color
-        }
-        return defaultBadgeColors[state] ?? .systemGray
-    }
-
-    override func mouseDown(with event: NSEvent) {
-        if event.clickCount == 2 {
-            startEditing()
-        } else {
-            dragStartPoint = convert(event.locationInWindow, from: nil)
-            _ = target?.perform(action, with: self)
-        }
-    }
-
-    override func rightMouseDown(with event: NSEvent) {
-        if let menu = onContextMenu?(event) {
-            NSMenu.popUpContextMenu(menu, with: event, for: self)
-        }
-    }
-
-    override func mouseDragged(with event: NSEvent) {
-        guard let start = dragStartPoint else { return }
-        let current = convert(event.locationInWindow, from: nil)
-        let distance = abs(current.y - start.y)
-        guard distance > 5 else { return }
-
-        dragStartPoint = nil
-
-        let pb = NSPasteboardItem()
-        pb.setString("\(index)", forType: deckardProjectDragType)
-        let item = NSDraggingItem(pasteboardWriter: pb)
-        item.setDraggingFrame(bounds, contents: snapshot())
-        beginDraggingSession(with: [item], event: event, source: self)
-    }
-
-    func draggingSession(_ session: NSDraggingSession, sourceOperationMaskFor context: NSDraggingContext) -> NSDragOperation {
-        return .move
-    }
-
-
-    private func snapshot() -> NSImage {
-        let image = NSImage(size: bounds.size)
-        image.lockFocus()
-        if let ctx = NSGraphicsContext.current?.cgContext {
-            layer?.render(in: ctx)
-        }
-        image.unlockFocus()
-        return image
-    }
-
-    private func startEditing() {
-        label.isEditable = true
-        label.isSelectable = true
-        label.focusRingType = .none
-        label.delegate = self
-        label.becomeFirstResponder()
-        label.currentEditor()?.selectAll(nil)
-    }
-
-    private func finishEditing() {
-        label.isEditable = false
-        label.isSelectable = false
-        let newName = label.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        if newName.isEmpty {
-            // Reset to default name
-            onClearName?()
-        } else if newName != title {
-            title = newName
-            onRename?(newName)
-        } else {
-            label.stringValue = title
-        }
-    }
-
-    func controlTextDidEndEditing(_ obj: Notification) {
-        finishEditing()
-    }
-
-    func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
-        if commandSelector == #selector(insertNewline(_:)) {
-            finishEditing()
-            window?.makeFirstResponder(nil)
-            return true
-        }
-        if commandSelector == #selector(cancelOperation(_:)) {
-            label.stringValue = title
-            label.isEditable = false
-            window?.makeFirstResponder(nil)
-            return true
-        }
-        return false
-    }
-}
-
-// MARK: - HorizontalTabView
-
-/// A single tab in the horizontal tab bar.
-let deckardTabDragType = NSPasteboard.PasteboardType("com.deckard.tab-reorder")
-
-class HorizontalTabView: NSView, NSTextFieldDelegate, NSDraggingSource {
-    override var mouseDownCanMoveWindow: Bool { false }
-    let index: Int
-    private let label: NSTextField
-    private weak var target: AnyObject?
-    private let clickAction: Selector
-    private var isSelected: Bool
-    var onRename: ((String) -> Void)?
-    var onClearName: (() -> Void)?
-    var onEditingFinished: (() -> Void)?
-    private var rawName: String
-
-    private var displayTitle: String
-    private var editWidthConstraint: NSLayoutConstraint?
-
-    private var badgeDot: NSView?
-
-    init(displayTitle: String, editableName: String, isClaude: Bool = false,
-         badgeState: TabItem.BadgeState = .none,
-         activity: ProcessMonitor.ActivityInfo? = nil,
-         isSelected: Bool, index: Int,
-         target: AnyObject, clickAction: Selector) {
-        self.index = index
-        self.isSelected = isSelected
-        self.target = target
-        self.clickAction = clickAction
-        self.rawName = editableName
-        self.displayTitle = displayTitle
-
-        label = NSTextField(labelWithString: displayTitle)
-        label.font = .systemFont(ofSize: 12)
-        let tc = ThemeManager.shared.currentColors
-        label.textColor = isSelected ? tc.primaryText : tc.secondaryText
-        label.lineBreakMode = .byTruncatingTail
-        label.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-        label.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
-
-        super.init(frame: .zero)
-        translatesAutoresizingMaskIntoConstraints = false
-        wantsLayer = true
-
-        // Badge dot — positioned on the right by layout constraints below
-        if badgeState != .none {
-            let dot = NSView()
-            dot.wantsLayer = true
-            dot.layer?.cornerRadius = 3.5
-            dot.layer?.backgroundColor = VerticalTabRowView.colorForBadge(badgeState).cgColor
-            dot.toolTip = VerticalTabRowView.tooltipForBadge(badgeState, activity: activity)
-            dot.translatesAutoresizingMaskIntoConstraints = false
-            addSubview(dot)
-            NSLayoutConstraint.activate([
-                dot.widthAnchor.constraint(equalToConstant: 7),
-                dot.heightAnchor.constraint(equalToConstant: 7),
-                dot.centerYAnchor.constraint(equalTo: centerYAnchor),
-            ])
-            if SettingsWindowController.isBadgeAnimated(badgeState) {
-                VerticalTabRowView.addPulseAnimation(to: dot)
-            }
-            badgeDot = dot
-        }
-
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.toolTip = shortcutTooltip("Close Tab", for: .closeTab)
-        addSubview(label)
-
-        // Layout: [label] [badge]
-        var constraints = [
-            heightAnchor.constraint(equalToConstant: 28),
-            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 6),
-            label.centerYAnchor.constraint(equalTo: centerYAnchor),
-        ]
-
-        if let dot = badgeDot {
-            constraints.append(dot.leadingAnchor.constraint(equalTo: label.trailingAnchor, constant: 5))
-            constraints.append(dot.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -6))
-        } else {
-            constraints.append(label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -6))
-        }
-
-        NSLayoutConstraint.activate(constraints)
-
-        if isSelected {
-            layer?.backgroundColor = ThemeManager.shared.currentColors.selectedBackground.cgColor
-        }
-
-    }
-
-    required init?(coder: NSCoder) { fatalError() }
-
-    private var dragStartPoint: NSPoint?
-
-    override func mouseDown(with event: NSEvent) {
-        if event.clickCount == 2 {
-            startEditing()
-        } else {
-            dragStartPoint = convert(event.locationInWindow, from: nil)
-            // Switch terminal immediately so the action isn't lost
-            // if a tab bar rebuild destroys this view before mouseUp.
-            (target as? DeckardWindowController)?.switchToTab(at: index)
-        }
-    }
-
-    override func mouseUp(with event: NSEvent) {
-        guard dragStartPoint != nil else { return }
-        dragStartPoint = nil
-        // Rebuild the tab bar to update the visual selection state.
-        (target as? DeckardWindowController)?.rebuildTabBar()
-    }
-
-    override func mouseDragged(with event: NSEvent) {
-        guard let start = dragStartPoint else { return }
-        let current = convert(event.locationInWindow, from: nil)
-        guard abs(current.x - start.x) > 5 else { return }
-
-        dragStartPoint = nil
-        let pb = NSPasteboardItem()
-        pb.setString("\(index)", forType: deckardTabDragType)
-        let item = NSDraggingItem(pasteboardWriter: pb)
-        let snapshot = NSImage(size: bounds.size)
-        snapshot.lockFocus()
-        if let ctx = NSGraphicsContext.current?.cgContext { layer?.render(in: ctx) }
-        snapshot.unlockFocus()
-        item.setDraggingFrame(bounds, contents: snapshot)
-        beginDraggingSession(with: [item], event: event, source: self)
-    }
-
-    func draggingSession(_ session: NSDraggingSession, sourceOperationMaskFor context: NSDraggingContext) -> NSDragOperation {
-        return .move
-    }
-
-    private func startEditing() {
-        isEditing = true
-        let w = max(label.fittingSize.width + 16, 80)
-        editWidthConstraint = label.widthAnchor.constraint(equalToConstant: w)
-        editWidthConstraint?.isActive = true
-
-        label.isEditable = true
-        label.isSelectable = true
-        label.isBezeled = false
-        label.drawsBackground = false
-        label.focusRingType = .none
-        label.stringValue = rawName
-        label.delegate = self
-        label.becomeFirstResponder()
-        label.currentEditor()?.selectAll(nil)
-    }
-
-    private(set) var isEditing = false
-
-    private func finishEditing() {
-        guard isEditing else { return }
-        isEditing = false
-        editWidthConstraint?.isActive = false
-        editWidthConstraint = nil
-        label.isEditable = false
-        label.isSelectable = false
-        label.isBezeled = false
-        let newName = label.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        if newName.isEmpty {
-            onClearName?()  // reset to default name
-        } else if newName != rawName {
-            rawName = newName
-            onRename?(newName)
-        } else {
-            label.stringValue = displayTitle
-        }
-        onEditingFinished?()
-    }
-
-    func controlTextDidEndEditing(_ obj: Notification) {
-        finishEditing()
-    }
-
-    func control(_ control: NSControl, textView: NSTextView, doCommandBy sel: Selector) -> Bool {
-        if sel == #selector(insertNewline(_:)) {
-            finishEditing()
-            window?.makeFirstResponder(nil)
-            return true
-        }
-        if sel == #selector(cancelOperation(_:)) {
-            isEditing = false
-            label.stringValue = displayTitle
-            label.isEditable = false
-            label.isSelectable = false
-            window?.makeFirstResponder(nil)
-            onEditingFinished?()
-            return true
-        }
-        return false
-    }
-
-}
-
-// MARK: - AddTabButton
-
-/// + button: left-click adds Claude tab, right-click adds terminal tab.
-class AddTabButton: NSView {
-    override var mouseDownCanMoveWindow: Bool { false }
-    private let leftClickAction: () -> Void
-    private let rightClickAction: () -> Void
-    private let label: NSTextField
-
-    init(leftClickAction: @escaping () -> Void, rightClickAction: @escaping () -> Void) {
-        self.leftClickAction = leftClickAction
-        self.rightClickAction = rightClickAction
-        label = NSTextField(labelWithString: "  +")
-        label.font = .systemFont(ofSize: 12, weight: .medium)
-        label.textColor = ThemeManager.shared.currentColors.secondaryText
-        super.init(frame: .zero)
-        translatesAutoresizingMaskIntoConstraints = false
-        toolTip = shortcutTooltip("New Claude tab", for: .newClaudeTab)
-            + "\nShift-click or right-click: " + shortcutTooltip("new Terminal", for: .newTerminalTab)
-        label.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(label)
-        NSLayoutConstraint.activate([
-            label.centerYAnchor.constraint(equalTo: centerYAnchor),
-            label.leadingAnchor.constraint(equalTo: leadingAnchor),
-            label.trailingAnchor.constraint(equalTo: trailingAnchor),
-            widthAnchor.constraint(equalToConstant: 28),
-            heightAnchor.constraint(equalToConstant: 28),
-        ])
-    }
-
-    required init?(coder: NSCoder) { fatalError() }
-
-    override func mouseDown(with event: NSEvent) {
-        if event.modifierFlags.contains(.shift) {
-            rightClickAction()  // Shift+click opens terminal tab
-        } else {
-            leftClickAction()
-        }
-    }
-
-    override func rightMouseDown(with event: NSEvent) {
-        rightClickAction()
-    }
-}
-
-// MARK: - ReorderableStackView
-
-/// NSStackView subclass that accepts drops for reordering.
-class ReorderableStackView: NSStackView {
-    var onReorder: ((Int, Int) -> Void)?
-
-    private let dropIndicator: NSView = {
-        let v = NSView()
-        v.wantsLayer = true
-        v.layer?.backgroundColor = ThemeManager.shared.currentColors.foreground.withAlphaComponent(0.4).cgColor
-        v.isHidden = true
-        return v
-    }()
-    private var currentDropIndex: Int = -1
-
-    private func dropIndex(for sender: NSDraggingInfo) -> Int {
-        let location = convert(sender.draggingLocation, from: nil)
-        for (i, view) in arrangedSubviews.enumerated() {
-            if location.y > view.frame.midY {
-                return i
-            }
-        }
-        return arrangedSubviews.count
-    }
-
-    private func showIndicator(at index: Int) {
-        guard index != currentDropIndex else { return }
-        currentDropIndex = index
-
-        // Use frame-based positioning (no autolayout) for simplicity
-        if dropIndicator.superview !== self {
-            dropIndicator.removeFromSuperview()
-            addSubview(dropIndicator)
-        }
-        dropIndicator.isHidden = false
-
-        let yPos: CGFloat
-        if index < arrangedSubviews.count {
-            yPos = arrangedSubviews[index].frame.maxY - 1
-        } else if let last = arrangedSubviews.last {
-            yPos = last.frame.minY - 1
-        } else {
-            yPos = bounds.maxY - 1
-        }
-        dropIndicator.frame = NSRect(x: 8, y: yPos, width: bounds.width - 16, height: 2)
-    }
-
-    func showIndicatorAtEnd() {
-        showIndicator(at: arrangedSubviews.count)
-    }
-
-    func hideIndicator() {
-        dropIndicator.isHidden = true
-        currentDropIndex = -1
-    }
-
-    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
-        guard sender.draggingPasteboard.types?.contains(deckardProjectDragType) == true else { return [] }
-        showIndicator(at: dropIndex(for: sender))
-        return .move
-    }
-
-    override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
-        guard sender.draggingPasteboard.types?.contains(deckardProjectDragType) == true else { return [] }
-        showIndicator(at: dropIndex(for: sender))
-        return .move
-    }
-
-    override func draggingExited(_ sender: NSDraggingInfo?) {
-        hideIndicator()
-    }
-
-    override func draggingEnded(_ sender: NSDraggingInfo) {
-        hideIndicator()
-    }
-
-    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
-        hideIndicator()
-        guard let fromStr = sender.draggingPasteboard.string(forType: deckardProjectDragType),
-              let fromIndex = Int(fromStr) else { return false }
-
-        let toIndex = dropIndex(for: sender)
-        if toIndex != fromIndex {
-            onReorder?(fromIndex, toIndex)
-        }
-        return true
-    }
-}
-
-// MARK: - ReorderableHStackView
-
-/// Horizontal stack view that accepts drops for tab reordering.
-class ReorderableHStackView: NSStackView {
-    override var mouseDownCanMoveWindow: Bool { false }
-    var onReorder: ((Int, Int) -> Void)?
-    var tabCount: Int = 0  // number of tab views (excluding + button and spacer)
-
-    private let dropIndicator: NSView = {
-        let v = NSView()
-        v.wantsLayer = true
-        v.layer?.backgroundColor = ThemeManager.shared.currentColors.foreground.withAlphaComponent(0.4).cgColor
-        v.isHidden = true
-        return v
-    }()
-    private var currentDropIndex: Int = -1
-
-    private func dropIndex(for sender: NSDraggingInfo) -> Int {
-        let location = convert(sender.draggingLocation, from: nil)
-        for i in 0..<tabCount {
-            guard i < arrangedSubviews.count else { break }
-            let view = arrangedSubviews[i]
-            if location.x < view.frame.midX {
-                return i
-            }
-        }
-        return tabCount
-    }
-
-    private func showIndicator(at index: Int) {
-        guard index != currentDropIndex else { return }
-        currentDropIndex = index
-
-        if dropIndicator.superview !== self {
-            dropIndicator.removeFromSuperview()
-            addSubview(dropIndicator)
-        }
-        dropIndicator.isHidden = false
-
-        let xPos: CGFloat
-        if index < tabCount, index < arrangedSubviews.count {
-            xPos = arrangedSubviews[index].frame.minX - 1
-        } else if tabCount > 0, tabCount - 1 < arrangedSubviews.count {
-            xPos = arrangedSubviews[tabCount - 1].frame.maxX + 1
-        } else {
-            xPos = 0
-        }
-        dropIndicator.frame = NSRect(x: xPos, y: 4, width: 2, height: bounds.height - 8)
-    }
-
-    func hideIndicator() {
-        dropIndicator.isHidden = true
-        currentDropIndex = -1
-    }
-
-    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
-        guard sender.draggingPasteboard.types?.contains(deckardTabDragType) == true else { return [] }
-        showIndicator(at: dropIndex(for: sender))
-        return .move
-    }
-
-    override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
-        guard sender.draggingPasteboard.types?.contains(deckardTabDragType) == true else { return [] }
-        showIndicator(at: dropIndex(for: sender))
-        return .move
-    }
-
-    override func draggingExited(_ sender: NSDraggingInfo?) {
-        hideIndicator()
-    }
-
-    override func draggingEnded(_ sender: NSDraggingInfo) {
-        hideIndicator()
-    }
-
-    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
-        hideIndicator()
-        guard let fromStr = sender.draggingPasteboard.string(forType: deckardTabDragType),
-              let fromIndex = Int(fromStr) else { return false }
-
-        let toIndex = dropIndex(for: sender)
-        if toIndex != fromIndex {
-            onReorder?(fromIndex, toIndex)
-        }
-        return true
-    }
-}
-
-// MARK: - SidebarDropZone
-
-/// Covers the empty area below the project list; dropping here moves to end.
-class SidebarDropZone: NSView {
-    var onDrop: ((Int) -> Void)?
-    weak var sidebarStackView: ReorderableStackView?
-
-    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
-        guard sender.draggingPasteboard.types?.contains(deckardProjectDragType) == true else { return [] }
-        sidebarStackView?.showIndicatorAtEnd()
-        return .move
-    }
-
-    override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
-        guard sender.draggingPasteboard.types?.contains(deckardProjectDragType) == true else { return [] }
-        sidebarStackView?.showIndicatorAtEnd()
-        return .move
-    }
-
-    override func draggingExited(_ sender: NSDraggingInfo?) {
-        sidebarStackView?.hideIndicator()
-    }
-
-    override func draggingEnded(_ sender: NSDraggingInfo) {
-        sidebarStackView?.hideIndicator()
-    }
-
-    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
-        sidebarStackView?.hideIndicator()
-        guard let fromStr = sender.draggingPasteboard.string(forType: deckardProjectDragType),
-              let fromIndex = Int(fromStr) else { return false }
-        onDrop?(fromIndex)
-        return true
-    }
-}
-
+// MARK: - Collection Extension
 
 extension Collection {
     subscript(safe index: Index) -> Element? {
         indices.contains(index) ? self[index] : nil
     }
 }
+
+// MARK: - NSColor Extension
 
 extension NSColor {
     func toHex() -> String {

--- a/Sources/Window/SidebarController.swift
+++ b/Sources/Window/SidebarController.swift
@@ -1,0 +1,726 @@
+import AppKit
+
+// MARK: - Sidebar Controller Extension
+
+extension DeckardWindowController {
+
+    // MARK: - Sidebar Helpers
+
+    /// Build `sidebarOrder` from the flat projects array when no order exists yet (migration).
+    func ensureSidebarOrder() {
+        guard sidebarOrder.isEmpty, !projects.isEmpty else { return }
+        sidebarOrder = projects.map { .project($0.id) }
+    }
+
+    /// Remove a project from sidebarOrder and all folders' projectIds.
+    func removeSidebarReference(projectId: UUID) {
+        sidebarOrder.removeAll { item in
+            if case .project(let id) = item, id == projectId { return true }
+            return false
+        }
+        for folder in sidebarFolders {
+            folder.projectIds.removeAll { $0 == projectId }
+        }
+    }
+
+    /// Look up a ProjectItem by id.
+    func projectById(_ id: UUID) -> ProjectItem? {
+        projects.first { $0.id == id }
+    }
+
+    /// Returns the flat index into `projects` for a given project id, or -1.
+    func projectIndex(forId id: UUID) -> Int {
+        projects.firstIndex { $0.id == id } ?? -1
+    }
+
+    // MARK: - Sidebar Rebuild
+
+    func rebuildSidebar() {
+        let savedFR = window?.firstResponder
+        defer {
+            if let terminal = currentTerminalView, savedFR === terminal,
+               window?.firstResponder !== terminal {
+                DiagnosticLog.shared.log("sidebar",
+                    "rebuildSidebar: focus stolen! restoring terminal view")
+                window?.makeFirstResponder(terminal)
+            }
+        }
+        sidebarStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        ensureSidebarOrder()
+
+        // Map from arranged-subview index to flat project index (for selection highlight).
+        // Also used for drag-drop: we store a "sidebar row index" in the pasteboard.
+        var sidebarRowToProjectIndex: [Int: Int] = [:]
+        var rowIndex = 0
+
+        for sidebarItem in sidebarOrder {
+            switch sidebarItem {
+            case .project(let projectId):
+                guard let project = projectById(projectId) else { continue }
+                let pi = projectIndex(forId: projectId)
+                let row = VerticalTabRowView(title: project.name, bold: false, index: pi,
+                                     target: self, action: #selector(projectRowClicked(_:)))
+                row.badgeInfos = project.tabs.filter { $0.badgeState != .none }.map { tab in
+                    (state: tab.badgeState, name: tab.name, activity: self.terminalActivity[tab.id])
+                }
+                row.onRename = { [weak self] newName in
+                    guard let self = self else { return }
+                    project.name = newName
+                    self.saveState()
+                }
+                row.onClearName = { [weak self] in
+                    guard let self = self else { return }
+                    project.name = (project.path as NSString).lastPathComponent
+                    self.rebuildSidebar()
+                    self.saveState()
+                }
+                row.onContextMenu = { [weak self] event in
+                    guard let self = self else { return nil }
+                    return self.buildProjectContextMenu(for: project)
+                }
+                sidebarStackView.addArrangedSubview(row)
+                row.leadingAnchor.constraint(equalTo: sidebarStackView.leadingAnchor).isActive = true
+                row.trailingAnchor.constraint(equalTo: sidebarStackView.trailingAnchor).isActive = true
+                sidebarRowToProjectIndex[rowIndex] = pi
+                rowIndex += 1
+
+            case .folder(let folder):
+                // Folder header
+                let folderView = SidebarFolderView(
+                    folder: folder,
+                    projectCount: folder.projectIds.count
+                )
+                folderView.onToggle = { [weak self] fv in
+                    self?.folderToggleClicked(fv)
+                }
+                folderView.onDrop = { [weak self] fv, fromIndex in
+                    guard let self else { return }
+                    guard fromIndex >= 0, fromIndex < self.projects.count else { return }
+                    let project = self.projects[fromIndex]
+                    self.moveProjectIntoFolder(projectId: project.id, folder: fv.folder)
+                }
+
+                // Aggregate badge infos from all projects in the folder
+                var aggregatedBadges: [(state: TabItem.BadgeState, name: String, activity: ProcessMonitor.ActivityInfo?)] = []
+                for pid in folder.projectIds {
+                    if let project = projectById(pid) {
+                        for tab in project.tabs where tab.badgeState != .none {
+                            aggregatedBadges.append((state: tab.badgeState, name: tab.name, activity: self.terminalActivity[tab.id]))
+                        }
+                    }
+                }
+                folderView.badgeInfos = aggregatedBadges
+
+                folderView.onRename = { [weak self] newName in
+                    guard let self = self else { return }
+                    folder.name = newName
+                    self.saveState()
+                }
+                folderView.onContextMenu = { [weak self] event in
+                    guard let self = self else { return nil }
+                    return self.buildFolderContextMenu(for: folder)
+                }
+                folderView.rowIndex = rowIndex
+                sidebarStackView.addArrangedSubview(folderView)
+                folderView.leadingAnchor.constraint(equalTo: sidebarStackView.leadingAnchor).isActive = true
+                folderView.trailingAnchor.constraint(equalTo: sidebarStackView.trailingAnchor).isActive = true
+                rowIndex += 1
+
+                // Render projects inside the folder (if not collapsed)
+                if !folder.isCollapsed {
+                    for projectId in folder.projectIds {
+                        guard let project = projectById(projectId) else { continue }
+                        let pi = projectIndex(forId: projectId)
+                        let row = VerticalTabRowView(title: project.name, bold: false, index: pi,
+                                             target: self, action: #selector(projectRowClicked(_:)))
+                        row.indent = 16
+                        row.badgeInfos = project.tabs.filter { $0.badgeState != .none }.map { tab in
+                            (state: tab.badgeState, name: tab.name, activity: self.terminalActivity[tab.id])
+                        }
+                        row.onRename = { [weak self] newName in
+                            guard let self = self else { return }
+                            project.name = newName
+                            self.saveState()
+                        }
+                        row.onClearName = { [weak self] in
+                            guard let self = self else { return }
+                            project.name = (project.path as NSString).lastPathComponent
+                            self.rebuildSidebar()
+                            self.saveState()
+                        }
+                        row.onContextMenu = { [weak self] event in
+                            guard let self = self else { return nil }
+                            return self.buildProjectContextMenu(for: project)
+                        }
+                        sidebarStackView.addArrangedSubview(row)
+                        row.leadingAnchor.constraint(equalTo: sidebarStackView.leadingAnchor).isActive = true
+                        row.trailingAnchor.constraint(equalTo: sidebarStackView.trailingAnchor).isActive = true
+                        sidebarRowToProjectIndex[rowIndex] = pi
+                        rowIndex += 1
+                    }
+                }
+            }
+        }
+
+        sidebarStackView.registerForDraggedTypes([deckardProjectDragType, deckardSidebarDragType, deckardFolderDragType])
+        sidebarStackView.onReorder = { [weak self] from, to in
+            self?.handleSidebarDragReorder(fromProjectIndex: from, toRow: to)
+        }
+        sidebarStackView.onDropOntoFolder = { [weak self] folderView, fromIndex in
+            folderView.onDrop?(folderView, fromIndex)
+        }
+        sidebarStackView.onFolderReorder = { [weak self] fromRow, toRow in
+            self?.handleFolderDragReorder(fromRow: fromRow, toRow: toRow)
+        }
+        sidebarDropZone.onDrop = { [weak self] fromIndex in
+            guard let self = self, fromIndex >= 0, fromIndex < self.projects.count else { return }
+            let project = self.projects[fromIndex]
+            // If the project was inside a folder, move it out first
+            if self.sidebarFolders.contains(where: { $0.projectIds.contains(project.id) }) {
+                self.moveProjectOutOfFolder(projectId: project.id)
+            }
+            // Move the sidebarOrder item to the end
+            self.sidebarOrder.removeAll { item in
+                if case .project(let id) = item, id == project.id { return true }
+                return false
+            }
+            self.sidebarOrder.append(.project(project.id))
+            self.reorderProject(from: fromIndex, to: self.projects.count)
+        }
+        sidebarDropZone.onFolderDrop = { [weak self] fromRow in
+            guard let self else { return }
+            // Move folder to end of sidebarOrder
+            let infos = self.sidebarRowInfos()
+            guard fromRow >= 0, fromRow < infos.count, infos[fromRow].isFolder,
+                  let folderId = infos[fromRow].folderId else { return }
+            guard let orderIdx = self.sidebarOrder.firstIndex(where: {
+                if case .folder(let f) = $0, f.id == folderId { return true }
+                return false
+            }) else { return }
+            let item = self.sidebarOrder.remove(at: orderIdx)
+            self.sidebarOrder.append(item)
+            self.rebuildSidebar()
+            self.saveState()
+        }
+        sidebarDropZone.sidebarStackView = sidebarStackView
+        sidebarDropZone.onContextMenu = { [weak self] event in
+            let menu = NSMenu()
+            let item = NSMenuItem(title: "New Folder", action: #selector(self?.sidebarEmptyContextNewFolder), keyEquivalent: "")
+            item.target = self
+            menu.addItem(item)
+            return menu
+        }
+
+        updateSidebarSelection()
+    }
+
+    func reorderProject(from fromIndex: Int, to toIndex: Int) {
+        guard fromIndex != toIndex,
+              fromIndex >= 0, fromIndex < projects.count,
+              toIndex >= 0, toIndex <= projects.count else { return }
+
+        let project = projects.remove(at: fromIndex)
+        let insertAt = toIndex > fromIndex ? toIndex - 1 : toIndex
+        projects.insert(project, at: min(insertAt, projects.count))
+
+        // Update selected index
+        if selectedProjectIndex == fromIndex {
+            selectedProjectIndex = insertAt
+        } else if fromIndex < selectedProjectIndex && insertAt >= selectedProjectIndex {
+            selectedProjectIndex -= 1
+        } else if fromIndex > selectedProjectIndex && insertAt <= selectedProjectIndex {
+            selectedProjectIndex += 1
+        }
+
+        rebuildSidebar()
+        saveState()
+    }
+
+    // MARK: - Sidebar Row Info
+
+    /// Maps a sidebar stack view row index to a sidebarOrder-aware identifier.
+    /// Returns (sidebarOrderIndex, isFolder, isFolderChild, parentFolder, childIndex)
+    struct SidebarRowInfo {
+        var sidebarOrderIndex: Int
+        var isFolder: Bool
+        var parentFolder: SidebarFolder?
+        var childIndexInFolder: Int?
+        var projectId: UUID?
+        var folderId: UUID?
+    }
+
+    func sidebarRowInfos() -> [SidebarRowInfo] {
+        var infos: [SidebarRowInfo] = []
+        for (orderIdx, item) in sidebarOrder.enumerated() {
+            switch item {
+            case .project(let pid):
+                infos.append(SidebarRowInfo(
+                    sidebarOrderIndex: orderIdx, isFolder: false,
+                    parentFolder: nil, childIndexInFolder: nil,
+                    projectId: pid, folderId: nil))
+            case .folder(let folder):
+                infos.append(SidebarRowInfo(
+                    sidebarOrderIndex: orderIdx, isFolder: true,
+                    parentFolder: nil, childIndexInFolder: nil,
+                    projectId: nil, folderId: folder.id))
+                if !folder.isCollapsed {
+                    for (ci, pid) in folder.projectIds.enumerated() {
+                        infos.append(SidebarRowInfo(
+                            sidebarOrderIndex: orderIdx, isFolder: false,
+                            parentFolder: folder, childIndexInFolder: ci,
+                            projectId: pid, folderId: nil))
+                    }
+                }
+            }
+        }
+        return infos
+    }
+
+    // MARK: - Sidebar Drag Handling
+
+    /// Handle drag reorder in the sidebar.
+    /// `fromProjectIndex` is the flat projects array index (from the pasteboard).
+    /// `toRow` is the stack view row index of the drop target.
+    func handleSidebarDragReorder(fromProjectIndex: Int, toRow: Int) {
+        guard fromProjectIndex >= 0, fromProjectIndex < projects.count else { return }
+        let draggedProject = projects[fromProjectIndex]
+        let infos = sidebarRowInfos()
+        guard toRow >= 0, toRow < infos.count else {
+            // Drop past the end — move to top level at the end
+            let wasInFolder = sidebarFolders.contains { $0.projectIds.contains(draggedProject.id) }
+            if wasInFolder { moveProjectOutOfFolder(projectId: draggedProject.id) }
+            sidebarOrder.removeAll { if case .project(let id) = $0, id == draggedProject.id { return true }; return false }
+            sidebarOrder.append(.project(draggedProject.id))
+            rebuildSidebar()
+            saveState()
+            return
+        }
+
+        let toInfo = infos[toRow]
+
+        // Dropping onto a folder header → insert into folder
+        if toInfo.isFolder, let folderId = toInfo.folderId,
+           let folder = sidebarFolders.first(where: { $0.id == folderId }) {
+            moveProjectIntoFolder(projectId: draggedProject.id, folder: folder)
+            return
+        }
+
+        // Determine the target folder: either the row itself is a folder child,
+        // or the row above is (dropping after the last child in a folder).
+        let effectiveFolder: SidebarFolder?
+        let effectiveChildIndex: Int?
+        if let pf = toInfo.parentFolder {
+            effectiveFolder = pf
+            effectiveChildIndex = toInfo.childIndexInFolder
+        } else if toRow > 0, toRow - 1 < infos.count, let prevFolder = infos[toRow - 1].parentFolder {
+            // The previous row is a folder child — we're inserting at the end of that folder
+            effectiveFolder = prevFolder
+            effectiveChildIndex = prevFolder.projectIds.count
+        } else {
+            effectiveFolder = nil
+            effectiveChildIndex = nil
+        }
+
+        // Dropping between items inside the same folder → reorder within folder
+        let sourceFolder = sidebarFolders.first { $0.projectIds.contains(draggedProject.id) }
+        if let targetFolder = effectiveFolder, let sf = sourceFolder, sf.id == targetFolder.id {
+            // Reorder within the same folder
+            guard let fromIdx = sf.projectIds.firstIndex(of: draggedProject.id),
+                  let toIdx = effectiveChildIndex else { return }
+            sf.projectIds.remove(at: fromIdx)
+            let insertAt = toIdx > fromIdx ? min(toIdx - 1, sf.projectIds.count) : toIdx
+            sf.projectIds.insert(draggedProject.id, at: insertAt)
+            rebuildSidebar()
+            saveState()
+            return
+        }
+
+        // Dropping between items inside a different folder → move into that folder at position
+        if let targetFolder = effectiveFolder {
+            // Remove from source folder if needed
+            if let sf = sourceFolder {
+                sf.projectIds.removeAll { $0 == draggedProject.id }
+            } else {
+                // Remove from top-level sidebarOrder
+                sidebarOrder.removeAll { if case .project(let id) = $0, id == draggedProject.id { return true }; return false }
+            }
+            // Insert at position in target folder
+            let insertAt = toInfo.childIndexInFolder ?? targetFolder.projectIds.count
+            if !targetFolder.projectIds.contains(draggedProject.id) {
+                targetFolder.projectIds.insert(draggedProject.id, at: min(insertAt, targetFolder.projectIds.count))
+            }
+            rebuildSidebar()
+            saveState()
+            return
+        }
+
+        // Dropping at top level — reorder in sidebarOrder
+        if let sf = sourceFolder {
+            sf.projectIds.removeAll { $0 == draggedProject.id }
+            // Add as top-level project in sidebarOrder at the target position
+            let targetOrderIdx = toInfo.sidebarOrderIndex
+            // Remove existing top-level entry if any
+            sidebarOrder.removeAll { if case .project(let id) = $0, id == draggedProject.id { return true }; return false }
+            sidebarOrder.insert(.project(draggedProject.id), at: min(targetOrderIdx, sidebarOrder.count))
+        } else if let targetPid = toInfo.projectId {
+            // Both are top-level — reorder sidebarOrder
+            if let fromOrderIdx = sidebarOrder.firstIndex(where: {
+                if case .project(let id) = $0, id == draggedProject.id { return true }; return false
+            }), let targetOrderIdx = sidebarOrder.firstIndex(where: {
+                if case .project(let id) = $0, id == targetPid { return true }; return false
+            }) {
+                let item = sidebarOrder.remove(at: fromOrderIdx)
+                let insertIdx = targetOrderIdx > fromOrderIdx ? targetOrderIdx : targetOrderIdx
+                sidebarOrder.insert(item, at: min(insertIdx, sidebarOrder.count))
+            }
+        }
+
+        // Also reorder in the flat projects array
+        let fromPi = fromProjectIndex
+        if let pid = toInfo.projectId, let toPi = projects.firstIndex(where: { $0.id == pid }), fromPi != toPi {
+            reorderProject(from: fromPi, to: toPi)
+        } else {
+            rebuildSidebar()
+            saveState()
+        }
+    }
+
+    // MARK: - Folder Management
+
+    @objc func sidebarEmptyContextNewFolder() {
+        createSidebarFolder()
+    }
+
+    func createSidebarFolder(name: String = "New Folder") {
+        let folder = SidebarFolder(name: name)
+        sidebarFolders.append(folder)
+        sidebarOrder.append(.folder(folder))
+        rebuildSidebar()
+        saveState()
+        // Start editing the name immediately
+        if let folderView = sidebarStackView.arrangedSubviews.compactMap({ $0 as? SidebarFolderView }).last {
+            folderView.startEditing()
+        }
+    }
+
+    func deleteSidebarFolder(_ folder: SidebarFolder) {
+        // Move all projects inside the folder back to top level (ungrouped)
+        let orderIndex = sidebarOrder.firstIndex(where: {
+            if case .folder(let f) = $0, f.id == folder.id { return true }
+            return false
+        })
+
+        // Insert ungrouped project items in place of the folder
+        if let idx = orderIndex {
+            sidebarOrder.remove(at: idx)
+            var insertIdx = idx
+            for pid in folder.projectIds {
+                sidebarOrder.insert(.project(pid), at: insertIdx)
+                insertIdx += 1
+            }
+        }
+
+        sidebarFolders.removeAll { $0.id == folder.id }
+        rebuildSidebar()
+        saveState()
+    }
+
+    func moveProjectIntoFolder(projectId: UUID, folder: SidebarFolder) {
+        // Remove project from current location (top-level or another folder)
+        sidebarOrder.removeAll { item in
+            if case .project(let id) = item, id == projectId { return true }
+            return false
+        }
+        for f in sidebarFolders where f.id != folder.id {
+            f.projectIds.removeAll { $0 == projectId }
+        }
+
+        // Add to target folder
+        if !folder.projectIds.contains(projectId) {
+            folder.projectIds.append(projectId)
+        }
+
+        // Auto-expand folder when adding projects
+        folder.isCollapsed = false
+
+        rebuildSidebar()
+        saveState()
+    }
+
+    func moveProjectOutOfFolder(projectId: UUID) {
+        // Find which folder contains this project
+        guard let folder = sidebarFolders.first(where: { $0.projectIds.contains(projectId) }) else { return }
+        folder.projectIds.removeAll { $0 == projectId }
+
+        // Insert as ungrouped project right after the folder in sidebarOrder
+        if let folderIdx = sidebarOrder.firstIndex(where: {
+            if case .folder(let f) = $0, f.id == folder.id { return true }
+            return false
+        }) {
+            sidebarOrder.insert(.project(projectId), at: folderIdx + 1)
+        } else {
+            sidebarOrder.append(.project(projectId))
+        }
+
+        rebuildSidebar()
+        saveState()
+    }
+
+    func folderToggleClicked(_ sender: SidebarFolderView) {
+        let wasCollapsed = sender.folder.isCollapsed
+        sender.folder.isCollapsed.toggle()
+
+        // If collapsing a folder that contains the selected project, auto-expand it instead
+        if sender.folder.isCollapsed, let current = currentProject,
+           sender.folder.projectIds.contains(current.id) {
+            sender.folder.isCollapsed = false
+        }
+
+        DiagnosticLog.shared.log("sidebar",
+            "folderToggle: \(sender.folder.name) was=\(wasCollapsed) now=\(sender.folder.isCollapsed) projects=\(sender.folder.projectIds.count)")
+
+        rebuildSidebar()
+        saveState()
+    }
+
+    /// Handle drag-reorder of a folder row.
+    /// `fromRow` is the row index of the dragged folder, `toRow` is the drop target row.
+    func handleFolderDragReorder(fromRow: Int, toRow: Int) {
+        let infos = sidebarRowInfos()
+        guard fromRow >= 0, fromRow < infos.count, infos[fromRow].isFolder,
+              let folderId = infos[fromRow].folderId else { return }
+
+        // Find the folder's index in sidebarOrder
+        guard let fromOrderIdx = sidebarOrder.firstIndex(where: {
+            if case .folder(let f) = $0, f.id == folderId { return true }
+            return false
+        }) else { return }
+
+        // Determine target sidebarOrder index
+        let targetOrderIdx: Int
+        if toRow >= 0, toRow < infos.count {
+            targetOrderIdx = infos[toRow].sidebarOrderIndex
+        } else {
+            targetOrderIdx = sidebarOrder.count
+        }
+
+        guard fromOrderIdx != targetOrderIdx else { return }
+
+        let item = sidebarOrder.remove(at: fromOrderIdx)
+        let insertIdx = targetOrderIdx > fromOrderIdx ? min(targetOrderIdx - 1, sidebarOrder.count) : min(targetOrderIdx, sidebarOrder.count)
+        sidebarOrder.insert(item, at: insertIdx)
+
+        rebuildSidebar()
+        saveState()
+    }
+
+    // MARK: - Folder Context Menu
+
+    func buildFolderContextMenu(for folder: SidebarFolder) -> NSMenu {
+        let menu = NSMenu()
+
+        let renameItem = NSMenuItem(title: "Rename Folder", action: #selector(renameFolderMenuAction(_:)), keyEquivalent: "")
+        renameItem.target = self
+        renameItem.representedObject = folder
+        menu.addItem(renameItem)
+
+        menu.addItem(.separator())
+
+        let deleteItem = NSMenuItem(title: "Delete Folder", action: #selector(deleteFolderMenuAction(_:)), keyEquivalent: "")
+        deleteItem.target = self
+        deleteItem.representedObject = folder
+        menu.addItem(deleteItem)
+
+        return menu
+    }
+
+    @objc func renameFolderMenuAction(_ sender: NSMenuItem) {
+        guard let folder = sender.representedObject as? SidebarFolder else { return }
+        // Find the SidebarFolderView for this folder and start editing
+        for view in sidebarStackView.arrangedSubviews {
+            if let fv = view as? SidebarFolderView, fv.folder.id == folder.id {
+                fv.startEditing()
+                break
+            }
+        }
+    }
+
+    @objc func deleteFolderMenuAction(_ sender: NSMenuItem) {
+        guard let folder = sender.representedObject as? SidebarFolder else { return }
+        deleteSidebarFolder(folder)
+    }
+
+    // MARK: - Project Context Menu
+
+    class ResumeSessionInfo {
+        let project: ProjectItem
+        let sessionId: String
+        let tabName: String?
+        init(project: ProjectItem, sessionId: String, tabName: String?) {
+            self.project = project
+            self.sessionId = sessionId
+            self.tabName = tabName
+        }
+    }
+
+    func buildProjectContextMenu(for project: ProjectItem) -> NSMenu {
+        let menu = NSMenu()
+
+        let resumeItem = NSMenuItem(title: "Resume Session", action: nil, keyEquivalent: "")
+        let resumeSubmenu = NSMenu()
+
+        let sessions = ContextMonitor.shared.listSessions(forProjectPath: project.path)
+        let openSessionIds = Set(project.tabs.compactMap { $0.sessionId })
+        let resumable = sessions.filter { !openSessionIds.contains($0.sessionId) }
+
+        if resumable.isEmpty {
+            let emptyItem = NSMenuItem(title: "No sessions to resume", action: nil, keyEquivalent: "")
+            emptyItem.isEnabled = false
+            resumeSubmenu.addItem(emptyItem)
+        } else {
+            let savedNames = SessionManager.shared.loadSessionNames()
+            let formatter = RelativeDateTimeFormatter()
+            formatter.unitsStyle = .abbreviated
+
+            for session in resumable.prefix(50) {
+                let timeStr = formatter.localizedString(for: session.modificationDate, relativeTo: Date())
+                let savedName = savedNames[session.sessionId]
+
+                let title: String
+                if let name = savedName, !name.isEmpty {
+                    title = "\(timeStr) \u{2014} \(name)"
+                } else if !session.firstUserMessage.isEmpty {
+                    let msg = session.firstUserMessage.count > 60
+                        ? String(session.firstUserMessage.prefix(60)) + "\u{2026}"
+                        : session.firstUserMessage
+                    title = "\(timeStr) \u{2014} \(msg)"
+                } else {
+                    title = timeStr
+                }
+
+                let item = NSMenuItem(title: title, action: #selector(resumeSessionMenuAction(_:)), keyEquivalent: "")
+                item.target = self
+                item.representedObject = ResumeSessionInfo(project: project, sessionId: session.sessionId, tabName: savedName)
+                resumeSubmenu.addItem(item)
+            }
+        }
+
+        resumeItem.submenu = resumeSubmenu
+        menu.addItem(resumeItem)
+
+        menu.addItem(.separator())
+
+        // Folder options
+        let isInFolder = sidebarFolders.contains { $0.projectIds.contains(project.id) }
+
+        if isInFolder {
+            let moveOutItem = NSMenuItem(title: "Move Out of Folder", action: #selector(moveProjectOutOfFolderAction(_:)), keyEquivalent: "")
+            moveOutItem.target = self
+            moveOutItem.representedObject = project
+            menu.addItem(moveOutItem)
+        } else if !sidebarFolders.isEmpty {
+            let moveToItem = NSMenuItem(title: "Move to Folder", action: nil, keyEquivalent: "")
+            let moveSubmenu = NSMenu()
+            for folder in sidebarFolders {
+                let item = NSMenuItem(title: folder.name, action: #selector(moveProjectToFolderAction(_:)), keyEquivalent: "")
+                item.target = self
+                item.representedObject = MoveToFolderInfo(project: project, folder: folder)
+                moveSubmenu.addItem(item)
+            }
+            moveToItem.submenu = moveSubmenu
+            menu.addItem(moveToItem)
+        }
+
+        menu.addItem(.separator())
+
+        let newFolderItem = NSMenuItem(title: "New Folder", action: #selector(newFolderMenuAction), keyEquivalent: "")
+        newFolderItem.target = self
+        menu.addItem(newFolderItem)
+
+        menu.addItem(.separator())
+
+        let closeItem = NSMenuItem(title: "Close Folder", action: #selector(closeProjectMenuAction(_:)), keyEquivalent: "")
+        closeItem.target = self
+        closeItem.representedObject = project
+        menu.addItem(closeItem)
+
+        return menu
+    }
+
+    class MoveToFolderInfo {
+        let project: ProjectItem
+        let folder: SidebarFolder
+        init(project: ProjectItem, folder: SidebarFolder) {
+            self.project = project
+            self.folder = folder
+        }
+    }
+
+    @objc func moveProjectToFolderAction(_ sender: NSMenuItem) {
+        guard let info = sender.representedObject as? MoveToFolderInfo else { return }
+        moveProjectIntoFolder(projectId: info.project.id, folder: info.folder)
+    }
+
+    @objc func moveProjectOutOfFolderAction(_ sender: NSMenuItem) {
+        guard let project = sender.representedObject as? ProjectItem else { return }
+        moveProjectOutOfFolder(projectId: project.id)
+    }
+
+    @objc func newFolderMenuAction() {
+        createSidebarFolder()
+    }
+
+    @objc func closeProjectMenuAction(_ sender: NSMenuItem) {
+        guard let project = sender.representedObject as? ProjectItem,
+              let pi = projects.firstIndex(where: { $0.id == project.id }) else { return }
+        closeProject(at: pi)
+    }
+
+    @objc func resumeSessionMenuAction(_ sender: NSMenuItem) {
+        guard let info = sender.representedObject as? ResumeSessionInfo else { return }
+        let project = info.project
+        let sessionId = info.sessionId
+
+        createTabInProject(project, isClaude: true, name: info.tabName, sessionIdToResume: sessionId)
+        project.selectedTabIndex = project.tabs.count - 1
+
+        if let pi = projects.firstIndex(where: { $0.id == project.id }) {
+            if pi == selectedProjectIndex {
+                rebuildTabBar()
+                showTab(project.tabs[project.selectedTabIndex])
+            } else {
+                selectProject(at: pi)
+            }
+        }
+        saveState()
+    }
+
+    // MARK: - Sidebar Selection
+
+    func updateSidebarSelection() {
+        guard let currentProjectId = currentProject?.id else {
+            for view in sidebarStackView.arrangedSubviews {
+                if let row = view as? VerticalTabRowView {
+                    row.isSelected = false
+                }
+            }
+            return
+        }
+        for view in sidebarStackView.arrangedSubviews {
+            if let row = view as? VerticalTabRowView {
+                row.isSelected = (row.index == selectedProjectIndex)
+            } else if let fv = view as? SidebarFolderView {
+                // Highlight folder if it contains the selected project
+                fv.isContainingSelected = fv.folder.projectIds.contains(currentProjectId) && fv.folder.isCollapsed
+            }
+        }
+    }
+
+    @objc func openProjectClicked() {
+        AppDelegate.shared?.openProjectPicker()
+    }
+
+    @objc func projectRowClicked(_ sender: VerticalTabRowView) {
+        selectProject(at: sender.index)
+    }
+}

--- a/Sources/Window/SidebarViews.swift
+++ b/Sources/Window/SidebarViews.swift
@@ -1,0 +1,795 @@
+import AppKit
+
+// MARK: - VerticalTabRowView
+
+class VerticalTabRowView: NSView, NSTextFieldDelegate, NSDraggingSource {
+    var title: String {
+        didSet { label.stringValue = title }
+    }
+    var isSelected: Bool = false {
+        didSet { needsDisplay = true }
+    }
+    /// Badge info for each Claude tab in this project, shown as right-aligned dots.
+    var badgeInfos: [(state: TabItem.BadgeState, name: String, activity: ProcessMonitor.ActivityInfo?)] = [] {
+        didSet { updateBadgeDots() }
+    }
+    var onRename: ((String) -> Void)?
+    var onClearName: (() -> Void)?
+    var onReorder: ((Int, Int) -> Void)?
+    var onContextMenu: ((NSEvent) -> NSMenu?)?
+    let index: Int
+    private let label: NSTextField
+    private let badgeContainer: NSStackView
+    private weak var target: AnyObject?
+    private let action: Selector
+    private var dragStartPoint: NSPoint?
+    private var leadingConstraint: NSLayoutConstraint?
+
+    /// Leading indent (used for projects inside folders).
+    var indent: CGFloat = 0 {
+        didSet { leadingConstraint?.constant = 8 + indent }
+    }
+
+    init(title: String, bold: Bool, index: Int, target: AnyObject, action: Selector) {
+        self.title = title
+        self.index = index
+        self.target = target
+        self.action = action
+
+        label = NSTextField(labelWithString: title)
+        label.font = bold ? .boldSystemFont(ofSize: 12) : .systemFont(ofSize: 12)
+        label.textColor = ThemeManager.shared.currentColors.primaryText
+        label.lineBreakMode = .byTruncatingTail
+        label.maximumNumberOfLines = 1
+
+        badgeContainer = NSStackView()
+        badgeContainer.orientation = .horizontal
+        badgeContainer.spacing = 3
+        badgeContainer.setContentHuggingPriority(.required, for: .horizontal)
+
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+        wantsLayer = true
+
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.toolTip = shortcutTooltip("Close Folder", for: .closeFolder)
+        badgeContainer.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(label)
+        addSubview(badgeContainer)
+
+        let lc = label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8)
+        self.leadingConstraint = lc
+
+        NSLayoutConstraint.activate([
+            heightAnchor.constraint(equalToConstant: 28),
+            lc,
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+            label.trailingAnchor.constraint(lessThanOrEqualTo: badgeContainer.leadingAnchor, constant: -4),
+            badgeContainer.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
+            badgeContainer.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func draw(_ dirtyRect: NSRect) {
+        if isSelected {
+            ThemeManager.shared.currentColors.selectedBackground.setFill()
+            bounds.fill()
+        }
+    }
+
+
+    private func updateBadgeDots() {
+        badgeContainer.arrangedSubviews.forEach {
+            $0.layer?.removeAllAnimations()
+            $0.removeFromSuperview()
+        }
+        for info in badgeInfos where info.state != .none {
+            let dot = NSView()
+            dot.wantsLayer = true
+            dot.layer?.cornerRadius = 3.5
+            dot.layer?.backgroundColor = Self.colorForBadge(info.state).cgColor
+            dot.toolTip = "\(info.name): \(Self.tooltipForBadge(info.state, activity: info.activity))"
+            dot.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                dot.widthAnchor.constraint(equalToConstant: 7),
+                dot.heightAnchor.constraint(equalToConstant: 7),
+            ])
+            if SettingsWindowController.isBadgeAnimated(info.state) {
+                Self.addPulseAnimation(to: dot)
+            }
+            badgeContainer.addArrangedSubview(dot)
+        }
+    }
+
+    static func addPulseAnimation(to view: NSView) {
+        guard let layer = view.layer else { return }
+        let anim = CABasicAnimation(keyPath: "opacity")
+        anim.fromValue = 1.0
+        anim.toValue = 0.3
+        anim.duration = 1.2
+        anim.autoreverses = true
+        anim.repeatCount = .infinity
+        anim.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        layer.add(anim, forKey: "pulse")
+    }
+
+    static func tooltipForBadge(_ state: TabItem.BadgeState, activity: ProcessMonitor.ActivityInfo? = nil) -> String {
+        switch state {
+        case .none: return ""
+        case .idle: return "Idle"
+        case .thinking: return "Thinking..."
+        case .waitingForInput: return "Waiting for input"
+        case .needsPermission: return "Needs permission"
+        case .error: return "Error"
+        case .terminalIdle: return "Idle"
+        case .terminalActive: return activity?.description ?? "Running"
+        case .terminalError: return "Error"
+        }
+    }
+
+    static let defaultBadgeColors: [TabItem.BadgeState: NSColor] = [
+        .idle: .systemGray,
+        .thinking: NSColor(red: 0.85, green: 0.65, blue: 0.2, alpha: 1.0),
+        .waitingForInput: NSColor(red: 0.65, green: 0.4, blue: 0.9, alpha: 1.0),
+        .needsPermission: .systemOrange,
+        .error: .systemRed,
+        .terminalIdle: NSColor(red: 0.35, green: 0.55, blue: 0.54, alpha: 1.0),
+        .terminalActive: NSColor(red: 0.45, green: 0.72, blue: 0.71, alpha: 1.0),
+        .terminalError: NSColor(red: 0.85, green: 0.3, blue: 0.3, alpha: 1.0),
+    ]
+
+    static func colorForBadge(_ state: TabItem.BadgeState) -> NSColor {
+        if state == .none { return .clear }
+        if let hex = UserDefaults.standard.string(forKey: "badgeColor.\(state.rawValue)"),
+           let color = NSColor.fromHex(hex) {
+            return color
+        }
+        return defaultBadgeColors[state] ?? .systemGray
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        if event.clickCount == 2 {
+            startEditing()
+        } else {
+            dragStartPoint = convert(event.locationInWindow, from: nil)
+            _ = target?.perform(action, with: self)
+        }
+    }
+
+    override func rightMouseDown(with event: NSEvent) {
+        if let menu = onContextMenu?(event) {
+            NSMenu.popUpContextMenu(menu, with: event, for: self)
+        }
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard let start = dragStartPoint else { return }
+        let current = convert(event.locationInWindow, from: nil)
+        let distance = abs(current.y - start.y)
+        guard distance > 5 else { return }
+
+        dragStartPoint = nil
+
+        let pb = NSPasteboardItem()
+        pb.setString("\(index)", forType: deckardProjectDragType)
+        let item = NSDraggingItem(pasteboardWriter: pb)
+        item.setDraggingFrame(bounds, contents: snapshot())
+        beginDraggingSession(with: [item], event: event, source: self)
+    }
+
+    func draggingSession(_ session: NSDraggingSession, sourceOperationMaskFor context: NSDraggingContext) -> NSDragOperation {
+        return .move
+    }
+
+
+    private func snapshot() -> NSImage {
+        let image = NSImage(size: bounds.size)
+        image.lockFocus()
+        if let ctx = NSGraphicsContext.current?.cgContext {
+            layer?.render(in: ctx)
+        }
+        image.unlockFocus()
+        return image
+    }
+
+    private func startEditing() {
+        label.isEditable = true
+        label.isSelectable = true
+        label.focusRingType = .none
+        label.delegate = self
+        label.becomeFirstResponder()
+        label.currentEditor()?.selectAll(nil)
+    }
+
+    private func finishEditing() {
+        label.isEditable = false
+        label.isSelectable = false
+        let newName = label.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if newName.isEmpty {
+            // Reset to default name
+            onClearName?()
+        } else if newName != title {
+            title = newName
+            onRename?(newName)
+        } else {
+            label.stringValue = title
+        }
+    }
+
+    func controlTextDidEndEditing(_ obj: Notification) {
+        finishEditing()
+    }
+
+    func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+        if commandSelector == #selector(insertNewline(_:)) {
+            finishEditing()
+            window?.makeFirstResponder(nil)
+            return true
+        }
+        if commandSelector == #selector(cancelOperation(_:)) {
+            label.stringValue = title
+            label.isEditable = false
+            window?.makeFirstResponder(nil)
+            return true
+        }
+        return false
+    }
+}
+
+// MARK: - SidebarFolderView
+
+/// A folder header row in the sidebar with disclosure triangle and name.
+class SidebarFolderView: NSView, NSTextFieldDelegate, NSDraggingSource {
+    let folder: SidebarFolder
+    private let disclosureButton: NSButton
+    private let label: NSTextField
+    private let badgeContainer: NSStackView
+
+    var onToggle: ((SidebarFolderView) -> Void)?
+    var onRename: ((String) -> Void)?
+    var onContextMenu: ((NSEvent) -> NSMenu?)?
+    var onDrop: ((SidebarFolderView, Int) -> Void)?  // folder, project index
+
+    /// Row index in the sidebar stack view (set during rebuildSidebar).
+    var rowIndex: Int = 0
+    private var dragStartPoint: NSPoint?
+    private var didDrag = false
+
+    /// Highlight when a dragged item hovers over this folder.
+    var isDropTarget: Bool = false {
+        didSet { needsDisplay = true }
+    }
+
+    /// Badge info aggregated from all projects in the folder.
+    var badgeInfos: [(state: TabItem.BadgeState, name: String, activity: ProcessMonitor.ActivityInfo?)] = [] {
+        didSet { updateBadgeDots() }
+    }
+
+    /// True when the folder is collapsed and contains the selected project.
+    var isContainingSelected: Bool = false {
+        didSet { needsDisplay = true }
+    }
+
+    init(folder: SidebarFolder, projectCount: Int) {
+        self.folder = folder
+
+        disclosureButton = NSButton()
+        disclosureButton.isBordered = false
+        disclosureButton.title = ""
+        disclosureButton.image = NSImage(systemSymbolName: folder.isCollapsed ? "chevron.right" : "chevron.down",
+                                         accessibilityDescription: "Toggle folder")
+        disclosureButton.contentTintColor = ThemeManager.shared.currentColors.secondaryText
+        disclosureButton.imagePosition = .imageOnly
+
+        label = NSTextField(labelWithString: folder.name)
+        label.font = .systemFont(ofSize: 11, weight: .semibold)
+        label.textColor = ThemeManager.shared.currentColors.secondaryText
+        label.lineBreakMode = .byTruncatingTail
+        label.maximumNumberOfLines = 1
+
+        badgeContainer = NSStackView()
+        badgeContainer.orientation = .horizontal
+        badgeContainer.spacing = 3
+        badgeContainer.setContentHuggingPriority(.required, for: .horizontal)
+
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+        wantsLayer = true
+
+        disclosureButton.translatesAutoresizingMaskIntoConstraints = false
+        disclosureButton.target = self
+        disclosureButton.action = #selector(disclosureClicked(_:))
+        addSubview(disclosureButton)
+
+        label.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(label)
+
+        badgeContainer.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(badgeContainer)
+
+        NSLayoutConstraint.activate([
+            heightAnchor.constraint(equalToConstant: 28),
+            disclosureButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 2),
+            disclosureButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            disclosureButton.widthAnchor.constraint(equalToConstant: 24),
+            disclosureButton.heightAnchor.constraint(equalToConstant: 24),
+            label.leadingAnchor.constraint(equalTo: disclosureButton.trailingAnchor, constant: 0),
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+            label.trailingAnchor.constraint(lessThanOrEqualTo: badgeContainer.leadingAnchor, constant: -4),
+            badgeContainer.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
+            badgeContainer.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func draw(_ dirtyRect: NSRect) {
+        if isDropTarget {
+            NSColor.controlAccentColor.withAlphaComponent(0.3).setFill()
+            NSBezierPath(roundedRect: bounds.insetBy(dx: 2, dy: 1), xRadius: 4, yRadius: 4).fill()
+        } else if isContainingSelected {
+            ThemeManager.shared.currentColors.selectedBackground.withAlphaComponent(0.5).setFill()
+            bounds.fill()
+        }
+    }
+
+    @objc private func disclosureClicked(_ sender: NSButton) {
+        onToggle?(self)
+    }
+
+    func updateChevron() {
+        disclosureButton.image = NSImage(systemSymbolName: folder.isCollapsed ? "chevron.right" : "chevron.down",
+                                         accessibilityDescription: "Toggle folder")
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        if event.clickCount == 2 {
+            startEditing()
+        } else {
+            dragStartPoint = convert(event.locationInWindow, from: nil)
+            didDrag = false
+        }
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        // Only toggle collapse if we didn't initiate a drag
+        if !didDrag && dragStartPoint != nil {
+            onToggle?(self)
+        }
+        dragStartPoint = nil
+        didDrag = false
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard let start = dragStartPoint else { return }
+        let current = convert(event.locationInWindow, from: nil)
+        let distance = abs(current.y - start.y)
+        guard distance > 5 else { return }
+
+        didDrag = true
+        dragStartPoint = nil
+
+        let pb = NSPasteboardItem()
+        pb.setString("\(rowIndex)", forType: deckardFolderDragType)
+        let item = NSDraggingItem(pasteboardWriter: pb)
+        item.setDraggingFrame(bounds, contents: snapshot())
+        beginDraggingSession(with: [item], event: event, source: self)
+    }
+
+    func draggingSession(_ session: NSDraggingSession, sourceOperationMaskFor context: NSDraggingContext) -> NSDragOperation {
+        return .move
+    }
+
+    private func snapshot() -> NSImage {
+        let image = NSImage(size: bounds.size)
+        image.lockFocus()
+        if let ctx = NSGraphicsContext.current?.cgContext {
+            layer?.render(in: ctx)
+        }
+        image.unlockFocus()
+        return image
+    }
+
+    override func rightMouseDown(with event: NSEvent) {
+        if let menu = onContextMenu?(event) {
+            NSMenu.popUpContextMenu(menu, with: event, for: self)
+        }
+    }
+
+    func startEditing() {
+        label.isEditable = true
+        label.isSelectable = true
+        label.focusRingType = .none
+        label.delegate = self
+        label.becomeFirstResponder()
+        label.currentEditor()?.selectAll(nil)
+    }
+
+    private func finishEditing() {
+        label.isEditable = false
+        label.isSelectable = false
+        let newName = label.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !newName.isEmpty, newName != folder.name {
+            folder.name = newName
+            onRename?(newName)
+        } else {
+            label.stringValue = folder.name
+        }
+    }
+
+    func controlTextDidEndEditing(_ obj: Notification) {
+        finishEditing()
+    }
+
+    func control(_ control: NSControl, textView: NSTextView, doCommandBy sel: Selector) -> Bool {
+        if sel == #selector(insertNewline(_:)) {
+            finishEditing()
+            window?.makeFirstResponder(nil)
+            return true
+        }
+        if sel == #selector(cancelOperation(_:)) {
+            label.stringValue = folder.name
+            label.isEditable = false
+            window?.makeFirstResponder(nil)
+            return true
+        }
+        return false
+    }
+
+    private func updateBadgeDots() {
+        badgeContainer.arrangedSubviews.forEach {
+            $0.layer?.removeAllAnimations()
+            $0.removeFromSuperview()
+        }
+        // When collapsed, show aggregated badges; when expanded, hide them
+        // (individual project rows show their own badges)
+        guard folder.isCollapsed else { return }
+        for info in badgeInfos where info.state != .none {
+            let dot = NSView()
+            dot.wantsLayer = true
+            dot.layer?.cornerRadius = 3.5
+            dot.layer?.backgroundColor = VerticalTabRowView.colorForBadge(info.state).cgColor
+            dot.toolTip = "\(info.name): \(VerticalTabRowView.tooltipForBadge(info.state, activity: info.activity))"
+            dot.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                dot.widthAnchor.constraint(equalToConstant: 7),
+                dot.heightAnchor.constraint(equalToConstant: 7),
+            ])
+            if SettingsWindowController.isBadgeAnimated(info.state) {
+                VerticalTabRowView.addPulseAnimation(to: dot)
+            }
+            badgeContainer.addArrangedSubview(dot)
+        }
+    }
+}
+
+// MARK: - SidebarDropZone
+
+/// Covers the empty area below the project list; dropping here moves to end.
+class SidebarDropZone: NSView {
+    var onDrop: ((Int) -> Void)?
+    var onFolderDrop: ((Int) -> Void)?  // folder row index dropped to bottom
+    var onContextMenu: ((NSEvent) -> NSMenu?)?
+    weak var sidebarStackView: ReorderableStackView?
+
+    override func rightMouseDown(with event: NSEvent) {
+        if let menu = onContextMenu?(event) {
+            NSMenu.popUpContextMenu(menu, with: event, for: self)
+        }
+    }
+
+    private func acceptsDrag(_ sender: NSDraggingInfo) -> Bool {
+        let types = sender.draggingPasteboard.types ?? []
+        return types.contains(deckardProjectDragType) || types.contains(deckardFolderDragType)
+    }
+
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        guard acceptsDrag(sender) else { return [] }
+        sidebarStackView?.showIndicatorAtEnd()
+        return .move
+    }
+
+    override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
+        guard acceptsDrag(sender) else { return [] }
+        sidebarStackView?.showIndicatorAtEnd()
+        return .move
+    }
+
+    override func draggingExited(_ sender: NSDraggingInfo?) {
+        sidebarStackView?.hideIndicator()
+    }
+
+    override func draggingEnded(_ sender: NSDraggingInfo) {
+        sidebarStackView?.hideIndicator()
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        sidebarStackView?.hideIndicator()
+        if let fromStr = sender.draggingPasteboard.string(forType: deckardProjectDragType),
+           let fromIndex = Int(fromStr) {
+            onDrop?(fromIndex)
+            return true
+        }
+        if let fromStr = sender.draggingPasteboard.string(forType: deckardFolderDragType),
+           let fromRow = Int(fromStr) {
+            onFolderDrop?(fromRow)
+            return true
+        }
+        return false
+    }
+}
+
+// MARK: - ReorderableStackView
+
+/// NSStackView subclass that accepts drops for reordering.
+/// Supports project drag (reorder/drop onto folder) and folder drag (reorder folders).
+class ReorderableStackView: NSStackView {
+    var onReorder: ((Int, Int) -> Void)?
+    var onDropOntoFolder: ((SidebarFolderView, Int) -> Void)?
+    var onFolderReorder: ((Int, Int) -> Void)?
+
+    private let dropIndicator: NSView = {
+        let v = NSView()
+        v.wantsLayer = true
+        v.layer?.backgroundColor = ThemeManager.shared.currentColors.foreground.withAlphaComponent(0.4).cgColor
+        v.isHidden = true
+        return v
+    }()
+    private var currentDropIndex: Int = -1
+    private weak var highlightedFolder: SidebarFolderView?
+
+    private func dropIndex(for sender: NSDraggingInfo) -> Int {
+        let location = convert(sender.draggingLocation, from: nil)
+        for (i, view) in arrangedSubviews.enumerated() {
+            if location.y > view.frame.midY {
+                return i
+            }
+        }
+        return arrangedSubviews.count
+    }
+
+    /// Returns the SidebarFolderView at the drag location, if the cursor is
+    /// within the center region of a folder row. The top and bottom edges
+    /// (6px each) are reserved for between-item line indicator drops.
+    private func folderView(at sender: NSDraggingInfo) -> SidebarFolderView? {
+        let location = convert(sender.draggingLocation, from: nil)
+        let edgeInset: CGFloat = 6
+        for view in arrangedSubviews {
+            guard let fv = view as? SidebarFolderView else { continue }
+            let innerTop = fv.frame.maxY - edgeInset
+            let innerBottom = fv.frame.minY + edgeInset
+            if location.y <= innerTop && location.y >= innerBottom {
+                return fv
+            }
+        }
+        return nil
+    }
+
+    private func clearFolderHighlight() {
+        if let prev = highlightedFolder {
+            prev.isDropTarget = false
+            highlightedFolder = nil
+        }
+    }
+
+    private func showIndicator(at index: Int, forceFullWidth: Bool = false) {
+        guard index != currentDropIndex else { return }
+        currentDropIndex = index
+
+        // Use frame-based positioning (no autolayout) for simplicity
+        if dropIndicator.superview !== self {
+            dropIndicator.removeFromSuperview()
+            addSubview(dropIndicator)
+        }
+        dropIndicator.isHidden = false
+
+        let yPos: CGFloat
+        if index < arrangedSubviews.count {
+            yPos = arrangedSubviews[index].frame.maxY - 1
+        } else if let last = arrangedSubviews.last {
+            yPos = last.frame.minY - 1
+        } else {
+            yPos = bounds.maxY - 1
+        }
+
+        // Indent the indicator when between items inside a folder (project drags only)
+        let leftInset: CGFloat
+        if forceFullWidth {
+            leftInset = 8
+        } else if index < arrangedSubviews.count,
+           let row = arrangedSubviews[index] as? VerticalTabRowView, row.indent > 0 {
+            leftInset = 24
+        } else if index > 0, index - 1 < arrangedSubviews.count,
+                  let prevRow = arrangedSubviews[index - 1] as? VerticalTabRowView, prevRow.indent > 0 {
+            leftInset = 24
+        } else {
+            leftInset = 8
+        }
+        dropIndicator.frame = NSRect(x: leftInset, y: yPos, width: bounds.width - leftInset - 8, height: 2)
+    }
+
+    func showIndicatorAtEnd() {
+        showIndicator(at: arrangedSubviews.count, forceFullWidth: true)
+    }
+
+    func hideIndicator() {
+        dropIndicator.isHidden = true
+        currentDropIndex = -1
+        clearFolderHighlight()
+    }
+
+    private func acceptsProjectDrag(_ sender: NSDraggingInfo) -> Bool {
+        sender.draggingPasteboard.types?.contains(deckardProjectDragType) == true
+    }
+
+    private func acceptsFolderDrag(_ sender: NSDraggingInfo) -> Bool {
+        sender.draggingPasteboard.types?.contains(deckardFolderDragType) == true
+    }
+
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        if acceptsProjectDrag(sender) {
+            return updateProjectDrag(sender)
+        } else if acceptsFolderDrag(sender) {
+            return updateFolderDrag(sender)
+        }
+        return []
+    }
+
+    override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
+        if acceptsProjectDrag(sender) {
+            return updateProjectDrag(sender)
+        } else if acceptsFolderDrag(sender) {
+            return updateFolderDrag(sender)
+        }
+        return []
+    }
+
+    /// Folder drag: only show indicator between top-level items (not inside folders).
+    private func updateFolderDrag(_ sender: NSDraggingInfo) -> NSDragOperation {
+        let snapped = snapToTopLevel(for: sender)
+        showIndicator(at: snapped, forceFullWidth: true)
+        return .move
+    }
+
+    /// Snap drop position to the nearest top-level boundary.
+    /// Indented rows (inside folders) are skipped — the indicator jumps to
+    /// the folder header above or the next top-level item below.
+    private func snapToTopLevel(for sender: NSDraggingInfo) -> Int {
+        let raw = dropIndex(for: sender)
+        // If dropping at a top-level position, use it directly
+        if raw < arrangedSubviews.count {
+            let view = arrangedSubviews[raw]
+            let isIndented = (view as? VerticalTabRowView)?.indent ?? 0 > 0
+            if !isIndented { return raw }
+        }
+        // Find the nearest top-level row above
+        var best = raw
+        for i in stride(from: raw - 1, through: 0, by: -1) {
+            let view = arrangedSubviews[i]
+            let isIndented = (view as? VerticalTabRowView)?.indent ?? 0 > 0
+            if !isIndented {
+                // Snap to just after this top-level item's group
+                // (after the folder + all its children)
+                best = i
+                // Find end of this folder's children
+                if view is SidebarFolderView {
+                    var end = i + 1
+                    while end < arrangedSubviews.count,
+                          let r = arrangedSubviews[end] as? VerticalTabRowView, r.indent > 0 {
+                        end += 1
+                    }
+                    best = end
+                }
+                break
+            }
+        }
+        return best
+    }
+
+    /// Common logic for project drag: highlight folder or show line indicator.
+    private func updateProjectDrag(_ sender: NSDraggingInfo) -> NSDragOperation {
+        if let fv = folderView(at: sender) {
+            // Hovering over a folder row — highlight it, hide the line indicator
+            dropIndicator.isHidden = true
+            currentDropIndex = -1
+            if highlightedFolder !== fv {
+                clearFolderHighlight()
+                fv.isDropTarget = true
+                highlightedFolder = fv
+            }
+        } else {
+            // Not over a folder — show the line indicator
+            clearFolderHighlight()
+            showIndicator(at: dropIndex(for: sender))
+        }
+        return .move
+    }
+
+    override func draggingExited(_ sender: NSDraggingInfo?) {
+        hideIndicator()
+    }
+
+    override func draggingEnded(_ sender: NSDraggingInfo) {
+        hideIndicator()
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        let wasOnFolder = highlightedFolder
+        hideIndicator()
+
+        // Handle project drag
+        if let fromStr = sender.draggingPasteboard.string(forType: deckardProjectDragType),
+           let fromIndex = Int(fromStr) {
+            // If dropped on a highlighted folder, route to folder drop handler
+            if let fv = wasOnFolder {
+                onDropOntoFolder?(fv, fromIndex)
+                return true
+            }
+            let toIndex = dropIndex(for: sender)
+            if toIndex != fromIndex {
+                onReorder?(fromIndex, toIndex)
+            }
+            return true
+        }
+
+        // Handle folder drag
+        if let fromStr = sender.draggingPasteboard.string(forType: deckardFolderDragType),
+           let fromRow = Int(fromStr) {
+            let toRow = dropIndex(for: sender)
+            if toRow != fromRow {
+                onFolderReorder?(fromRow, toRow)
+            }
+            return true
+        }
+
+        return false
+    }
+}
+
+// MARK: - AddTabButton
+
+/// + button: left-click adds Claude tab, right-click adds terminal tab.
+class AddTabButton: NSView {
+    override var mouseDownCanMoveWindow: Bool { false }
+    private let leftClickAction: () -> Void
+    private let rightClickAction: () -> Void
+    private let label: NSTextField
+
+    init(leftClickAction: @escaping () -> Void, rightClickAction: @escaping () -> Void) {
+        self.leftClickAction = leftClickAction
+        self.rightClickAction = rightClickAction
+        label = NSTextField(labelWithString: "  +")
+        label.font = .systemFont(ofSize: 12, weight: .medium)
+        label.textColor = ThemeManager.shared.currentColors.secondaryText
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+        toolTip = shortcutTooltip("New Claude tab", for: .newClaudeTab)
+            + "\nShift-click or right-click: " + shortcutTooltip("new Terminal", for: .newTerminalTab)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(label)
+        NSLayoutConstraint.activate([
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+            label.leadingAnchor.constraint(equalTo: leadingAnchor),
+            label.trailingAnchor.constraint(equalTo: trailingAnchor),
+            widthAnchor.constraint(equalToConstant: 28),
+            heightAnchor.constraint(equalToConstant: 28),
+        ])
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func mouseDown(with event: NSEvent) {
+        if event.modifierFlags.contains(.shift) {
+            rightClickAction()  // Shift+click opens terminal tab
+        } else {
+            leftClickAction()
+        }
+    }
+
+    override func rightMouseDown(with event: NSEvent) {
+        rightClickAction()
+    }
+}

--- a/Sources/Window/TabBarController.swift
+++ b/Sources/Window/TabBarController.swift
@@ -1,0 +1,152 @@
+import AppKit
+
+// MARK: - Tab Bar Controller Extension
+
+extension DeckardWindowController {
+
+    // MARK: - Tab Bar (horizontal tabs within selected project)
+
+    var isTabEditing: Bool {
+        tabBar.arrangedSubviews.contains { ($0 as? HorizontalTabView)?.isEditing == true }
+    }
+
+    func rebuildTabBar() {
+        guard !isRebuildingTabBar else { return }
+        if isTabEditing {
+            needsTabBarRebuild = true
+            return
+        }
+        isRebuildingTabBar = true
+        defer {
+            isRebuildingTabBar = false
+            // Restore focus if the rebuild stole it from the terminal
+            if let terminal = currentTerminalView, savedFirstResponder === terminal,
+               window?.firstResponder !== terminal {
+                DiagnosticLog.shared.log("tabbar",
+                    "rebuildTabBar: focus stolen! restoring terminal view")
+                window?.makeFirstResponder(terminal)
+            }
+            savedFirstResponder = nil
+        }
+        savedFirstResponder = window?.firstResponder
+
+        tabBar.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        guard let project = currentProject else { return }
+
+        for (i, tab) in project.tabs.enumerated() {
+            let isSelected = (i == project.selectedTabIndex)
+            let title = " \(tab.name) "
+
+            let tabView = HorizontalTabView(
+                displayTitle: title,
+                editableName: tab.name,
+                isClaude: tab.isClaude,
+                badgeState: tab.badgeState,
+                activity: terminalActivity[tab.id],
+                isSelected: isSelected,
+                index: i,
+                target: self,
+                clickAction: #selector(tabBarClicked(_:))
+            )
+            tabView.onRename = { [weak self] newName in
+                guard let self = self, let project = self.currentProject,
+                      i < project.tabs.count else { return }
+                let tab = project.tabs[i]
+                tab.name = newName
+                if let sid = tab.sessionId, !sid.isEmpty {
+                    SessionManager.shared.saveSessionName(sessionId: sid, name: newName)
+                }
+                self.rebuildTabBar()
+                self.saveState()
+            }
+            tabView.onClearName = { [weak self] in
+                guard let self = self, let project = self.currentProject,
+                      i < project.tabs.count else { return }
+                let tab = project.tabs[i]
+                let base = tab.isClaude ? "Claude" : "Terminal"
+                let sameType = project.tabs.filter { $0.isClaude == tab.isClaude }
+                tab.name = sameType.count <= 1 ? base : "\(base) #\(i + 1)"
+                self.rebuildTabBar()
+                self.saveState()
+            }
+            tabView.onEditingFinished = { [weak self] in
+                guard let self = self, self.needsTabBarRebuild else { return }
+                self.needsTabBarRebuild = false
+                self.rebuildTabBar()
+            }
+            tabBar.addArrangedSubview(tabView)
+        }
+
+        // Set up drag-to-reorder
+        tabBar.tabCount = project.tabs.count
+        tabBar.registerForDraggedTypes([deckardTabDragType])
+        tabBar.onReorder = { [weak self] from, to in
+            self?.reorderTab(from: from, to: to)
+        }
+
+        // Add "+" button
+        let addButton = AddTabButton(
+            leftClickAction: { [weak self] in self?.addTabToCurrentProject(isClaude: true) },
+            rightClickAction: { [weak self] in self?.addTabToCurrentProject(isClaude: false) }
+        )
+        tabBar.addArrangedSubview(addButton)
+
+        // Spacer
+        let spacer = NSView()
+        spacer.translatesAutoresizingMaskIntoConstraints = false
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        tabBar.addArrangedSubview(spacer)
+    }
+
+    func reorderTab(from fromIndex: Int, to toIndex: Int) {
+        guard let project = currentProject else { return }
+        guard fromIndex != toIndex,
+              fromIndex >= 0, fromIndex < project.tabs.count,
+              toIndex >= 0, toIndex <= project.tabs.count else { return }
+
+        let tab = project.tabs.remove(at: fromIndex)
+        let insertAt = toIndex > fromIndex ? toIndex - 1 : toIndex
+        project.tabs.insert(tab, at: min(insertAt, project.tabs.count))
+
+        if project.selectedTabIndex == fromIndex {
+            project.selectedTabIndex = insertAt
+        } else if fromIndex < project.selectedTabIndex && insertAt >= project.selectedTabIndex {
+            project.selectedTabIndex -= 1
+        } else if fromIndex > project.selectedTabIndex && insertAt <= project.selectedTabIndex {
+            project.selectedTabIndex += 1
+        }
+
+        rebuildTabBar()
+        rebuildSidebar()
+        saveState()
+    }
+
+    @objc func tabBarClicked(_ sender: HorizontalTabView) {
+        selectTabInProject(at: sender.index)
+    }
+
+    @objc func tabBarCloseClicked(_ sender: NSButton) {
+        guard let project = currentProject else { return }
+        let idx = sender.tag
+        guard idx >= 0, idx < project.tabs.count else { return }
+
+        let tab = project.tabs[idx]
+        tab.surface.terminate()
+        tabCreationOrder.removeAll { $0 == tab.id }
+
+        project.tabs.remove(at: idx)
+
+        if project.tabs.isEmpty {
+            currentTerminalView = nil
+            showEmptyState()
+            rebuildTabBar()
+            rebuildSidebar()
+        } else {
+            project.selectedTabIndex = min(idx, project.tabs.count - 1)
+            rebuildTabBar()
+            rebuildSidebar()
+            showTab(project.tabs[project.selectedTabIndex])
+        }
+        saveState()
+    }
+}

--- a/Sources/Window/TabBarViews.swift
+++ b/Sources/Window/TabBarViews.swift
@@ -1,0 +1,287 @@
+import AppKit
+
+// MARK: - HorizontalTabView
+
+/// A single tab in the horizontal tab bar.
+let deckardTabDragType = NSPasteboard.PasteboardType("com.deckard.tab-reorder")
+
+class HorizontalTabView: NSView, NSTextFieldDelegate, NSDraggingSource {
+    override var mouseDownCanMoveWindow: Bool { false }
+    let index: Int
+    private let label: NSTextField
+    private weak var target: AnyObject?
+    private let clickAction: Selector
+    private var isSelected: Bool
+    var onRename: ((String) -> Void)?
+    var onClearName: (() -> Void)?
+    var onEditingFinished: (() -> Void)?
+    private var rawName: String
+
+    private var displayTitle: String
+    private var editWidthConstraint: NSLayoutConstraint?
+
+    private var badgeDot: NSView?
+
+    init(displayTitle: String, editableName: String, isClaude: Bool = false,
+         badgeState: TabItem.BadgeState = .none,
+         activity: ProcessMonitor.ActivityInfo? = nil,
+         isSelected: Bool, index: Int,
+         target: AnyObject, clickAction: Selector) {
+        self.index = index
+        self.isSelected = isSelected
+        self.target = target
+        self.clickAction = clickAction
+        self.rawName = editableName
+        self.displayTitle = displayTitle
+
+        label = NSTextField(labelWithString: displayTitle)
+        label.font = .systemFont(ofSize: 12)
+        let tc = ThemeManager.shared.currentColors
+        label.textColor = isSelected ? tc.primaryText : tc.secondaryText
+        label.lineBreakMode = .byTruncatingTail
+        label.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        label.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+        wantsLayer = true
+
+        // Badge dot — positioned on the right by layout constraints below
+        if badgeState != .none {
+            let dot = NSView()
+            dot.wantsLayer = true
+            dot.layer?.cornerRadius = 3.5
+            dot.layer?.backgroundColor = VerticalTabRowView.colorForBadge(badgeState).cgColor
+            dot.toolTip = VerticalTabRowView.tooltipForBadge(badgeState, activity: activity)
+            dot.translatesAutoresizingMaskIntoConstraints = false
+            addSubview(dot)
+            NSLayoutConstraint.activate([
+                dot.widthAnchor.constraint(equalToConstant: 7),
+                dot.heightAnchor.constraint(equalToConstant: 7),
+                dot.centerYAnchor.constraint(equalTo: centerYAnchor),
+            ])
+            if SettingsWindowController.isBadgeAnimated(badgeState) {
+                VerticalTabRowView.addPulseAnimation(to: dot)
+            }
+            badgeDot = dot
+        }
+
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.toolTip = shortcutTooltip("Close Tab", for: .closeTab)
+        addSubview(label)
+
+        // Layout: [label] [badge]
+        var constraints = [
+            heightAnchor.constraint(equalToConstant: 28),
+            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 6),
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ]
+
+        if let dot = badgeDot {
+            constraints.append(dot.leadingAnchor.constraint(equalTo: label.trailingAnchor, constant: 5))
+            constraints.append(dot.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -6))
+        } else {
+            constraints.append(label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -6))
+        }
+
+        NSLayoutConstraint.activate(constraints)
+
+        if isSelected {
+            layer?.backgroundColor = ThemeManager.shared.currentColors.selectedBackground.cgColor
+        }
+
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    private var dragStartPoint: NSPoint?
+
+    override func mouseDown(with event: NSEvent) {
+        if event.clickCount == 2 {
+            startEditing()
+        } else {
+            dragStartPoint = convert(event.locationInWindow, from: nil)
+            // Switch terminal immediately so the action isn't lost
+            // if a tab bar rebuild destroys this view before mouseUp.
+            (target as? DeckardWindowController)?.switchToTab(at: index)
+        }
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        guard dragStartPoint != nil else { return }
+        dragStartPoint = nil
+        // Rebuild the tab bar to update the visual selection state.
+        (target as? DeckardWindowController)?.rebuildTabBar()
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard let start = dragStartPoint else { return }
+        let current = convert(event.locationInWindow, from: nil)
+        guard abs(current.x - start.x) > 5 else { return }
+
+        dragStartPoint = nil
+        let pb = NSPasteboardItem()
+        pb.setString("\(index)", forType: deckardTabDragType)
+        let item = NSDraggingItem(pasteboardWriter: pb)
+        let snapshot = NSImage(size: bounds.size)
+        snapshot.lockFocus()
+        if let ctx = NSGraphicsContext.current?.cgContext { layer?.render(in: ctx) }
+        snapshot.unlockFocus()
+        item.setDraggingFrame(bounds, contents: snapshot)
+        beginDraggingSession(with: [item], event: event, source: self)
+    }
+
+    func draggingSession(_ session: NSDraggingSession, sourceOperationMaskFor context: NSDraggingContext) -> NSDragOperation {
+        return .move
+    }
+
+    private func startEditing() {
+        isEditing = true
+        let w = max(label.fittingSize.width + 16, 80)
+        editWidthConstraint = label.widthAnchor.constraint(equalToConstant: w)
+        editWidthConstraint?.isActive = true
+
+        label.isEditable = true
+        label.isSelectable = true
+        label.isBezeled = false
+        label.drawsBackground = false
+        label.focusRingType = .none
+        label.stringValue = rawName
+        label.delegate = self
+        label.becomeFirstResponder()
+        label.currentEditor()?.selectAll(nil)
+    }
+
+    private(set) var isEditing = false
+
+    private func finishEditing() {
+        guard isEditing else { return }
+        isEditing = false
+        editWidthConstraint?.isActive = false
+        editWidthConstraint = nil
+        label.isEditable = false
+        label.isSelectable = false
+        label.isBezeled = false
+        let newName = label.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if newName.isEmpty {
+            onClearName?()  // reset to default name
+        } else if newName != rawName {
+            rawName = newName
+            onRename?(newName)
+        } else {
+            label.stringValue = displayTitle
+        }
+        onEditingFinished?()
+    }
+
+    func controlTextDidEndEditing(_ obj: Notification) {
+        finishEditing()
+    }
+
+    func control(_ control: NSControl, textView: NSTextView, doCommandBy sel: Selector) -> Bool {
+        if sel == #selector(insertNewline(_:)) {
+            finishEditing()
+            window?.makeFirstResponder(nil)
+            return true
+        }
+        if sel == #selector(cancelOperation(_:)) {
+            isEditing = false
+            label.stringValue = displayTitle
+            label.isEditable = false
+            label.isSelectable = false
+            window?.makeFirstResponder(nil)
+            onEditingFinished?()
+            return true
+        }
+        return false
+    }
+
+}
+
+// MARK: - ReorderableHStackView
+
+/// Horizontal stack view that accepts drops for tab reordering.
+class ReorderableHStackView: NSStackView {
+    override var mouseDownCanMoveWindow: Bool { false }
+    var onReorder: ((Int, Int) -> Void)?
+    var tabCount: Int = 0  // number of tab views (excluding + button and spacer)
+
+    private let dropIndicator: NSView = {
+        let v = NSView()
+        v.wantsLayer = true
+        v.layer?.backgroundColor = ThemeManager.shared.currentColors.foreground.withAlphaComponent(0.4).cgColor
+        v.isHidden = true
+        return v
+    }()
+    private var currentDropIndex: Int = -1
+
+    private func dropIndex(for sender: NSDraggingInfo) -> Int {
+        let location = convert(sender.draggingLocation, from: nil)
+        for i in 0..<tabCount {
+            guard i < arrangedSubviews.count else { break }
+            let view = arrangedSubviews[i]
+            if location.x < view.frame.midX {
+                return i
+            }
+        }
+        return tabCount
+    }
+
+    private func showIndicator(at index: Int) {
+        guard index != currentDropIndex else { return }
+        currentDropIndex = index
+
+        if dropIndicator.superview !== self {
+            dropIndicator.removeFromSuperview()
+            addSubview(dropIndicator)
+        }
+        dropIndicator.isHidden = false
+
+        let xPos: CGFloat
+        if index < tabCount, index < arrangedSubviews.count {
+            xPos = arrangedSubviews[index].frame.minX - 1
+        } else if tabCount > 0, tabCount - 1 < arrangedSubviews.count {
+            xPos = arrangedSubviews[tabCount - 1].frame.maxX + 1
+        } else {
+            xPos = 0
+        }
+        dropIndicator.frame = NSRect(x: xPos, y: 4, width: 2, height: bounds.height - 8)
+    }
+
+    func hideIndicator() {
+        dropIndicator.isHidden = true
+        currentDropIndex = -1
+    }
+
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        guard sender.draggingPasteboard.types?.contains(deckardTabDragType) == true else { return [] }
+        showIndicator(at: dropIndex(for: sender))
+        return .move
+    }
+
+    override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
+        guard sender.draggingPasteboard.types?.contains(deckardTabDragType) == true else { return [] }
+        showIndicator(at: dropIndex(for: sender))
+        return .move
+    }
+
+    override func draggingExited(_ sender: NSDraggingInfo?) {
+        hideIndicator()
+    }
+
+    override func draggingEnded(_ sender: NSDraggingInfo) {
+        hideIndicator()
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        hideIndicator()
+        guard let fromStr = sender.draggingPasteboard.string(forType: deckardTabDragType),
+              let fromIndex = Int(fromStr) else { return false }
+
+        let toIndex = dropIndex(for: sender)
+        if toIndex != fromIndex {
+            onReorder?(fromIndex, toIndex)
+        }
+        return true
+    }
+}


### PR DESCRIPTION
## Summary

- Add optional folders to the sidebar for grouping related projects (e.g., by client)
- Folders are collapsible (disclosure triangle), renamable (double-click), and deletable (right-click)
- Projects can be dragged into and out of folders via drag-and-drop
- Ungrouped projects remain at the top level — folders are optional
- Folder structure persists across restarts
- Badge dots on folder headers aggregate badges from all contained projects
- Selecting a project inside a collapsed folder auto-expands it
- Context menus: "Move to Folder" submenu on projects, "Rename/Delete Folder" on folders
- "New Sidebar Folder" added to File menu
- Backward-compatible — existing state files (no folders) migrate cleanly

## Test plan

- [ ] Create a folder via File > New Sidebar Folder
- [ ] Rename the folder by double-clicking its label
- [ ] Drag a project into the folder — verify it appears indented inside
- [ ] Drag a project out of the folder — verify it returns to top level
- [ ] Collapse the folder — verify projects are hidden
- [ ] Select a project inside a collapsed folder — verify folder auto-expands
- [ ] Right-click folder > Delete Folder — verify projects become ungrouped (not deleted)
- [ ] Quit and relaunch — verify folder structure persists
- [ ] Verify badge dots aggregate on the folder header

🤖 Generated with [Claude Code](https://claude.com/claude-code)