### PR TITLE
fix: preserve user's custom statusLine config (#39)

### DIFF
--- a/Sources/App/DeckardHooksInstaller.swift
+++ b/Sources/App/DeckardHooksInstaller.swift
@@ -83,6 +83,10 @@ enum DeckardHooksInstaller {
         NSHomeDirectory() + "/.claude/settings.json"
     }()
 
+    private static let originalStatusLinePath: String = {
+        NSHomeDirectory() + "/.deckard/original-statusline.json"
+    }()
+
     private static let hookEvents: [(key: String, arg: String)] = [
         ("SessionStart", "session-start"),
         ("Stop", "stop"),
@@ -111,18 +115,20 @@ enum DeckardHooksInstaller {
         }
     }
 
-    private static func mergeHooksIntoSettings() {
+    static func mergeHooksIntoSettings(settingsPath: String? = nil, originalStatusLinePath: String? = nil) {
+        let effectiveSettingsPath = settingsPath ?? Self.settingsPath
+        let effectiveOriginalPath = originalStatusLinePath ?? Self.originalStatusLinePath
         let fm = FileManager.default
 
         // Ensure ~/.claude/ exists
-        let claudeDir = NSHomeDirectory() + "/.claude"
+        let claudeDir = (effectiveSettingsPath as NSString).deletingLastPathComponent
         if !fm.fileExists(atPath: claudeDir) {
             try? fm.createDirectory(atPath: claudeDir, withIntermediateDirectories: true)
         }
 
         // Read existing settings (or start fresh)
         var settings: [String: Any] = [:]
-        if let data = fm.contents(atPath: settingsPath),
+        if let data = fm.contents(atPath: effectiveSettingsPath),
            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
             settings = json
         }
@@ -160,6 +166,13 @@ enum DeckardHooksInstaller {
 
         settings["hooks"] = hooks
 
+        // Save original statusLine if it's not ours
+        if let statusLine = settings["statusLine"] as? [String: Any],
+           let cmd = statusLine["command"] as? String,
+           !cmd.contains(".deckard/hooks/") {
+            saveOriginalStatusLine(statusLine, to: effectiveOriginalPath)
+        }
+
         // Configure statusLine command to receive rate_limits from Claude Code.
         // The statusLine receives the full /status JSON on stdin (which includes
         // rate_limits) — unlike regular hooks which only get event-specific data.
@@ -173,7 +186,18 @@ enum DeckardHooksInstaller {
             withJSONObject: settings,
             options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
         ) {
-            try? data.write(to: URL(fileURLWithPath: settingsPath))
+            try? data.write(to: URL(fileURLWithPath: effectiveSettingsPath))
+        }
+    }
+
+    private static func saveOriginalStatusLine(_ config: [String: Any], to path: String) {
+        let dir = (path as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        if let data = try? JSONSerialization.data(
+            withJSONObject: config,
+            options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        ) {
+            try? data.write(to: URL(fileURLWithPath: path))
         }
     }
 }

--- a/Sources/App/DeckardHooksInstaller.swift
+++ b/Sources/App/DeckardHooksInstaller.swift
@@ -105,6 +105,10 @@ enum DeckardHooksInstaller {
         NSHomeDirectory() + "/.deckard/original-statusline.json"
     }()
 
+    private static let hooksDirPath: String = {
+        NSHomeDirectory() + "/.deckard/hooks"
+    }()
+
     private static let hookEvents: [(key: String, arg: String)] = [
         ("SessionStart", "session-start"),
         ("Stop", "stop"),
@@ -218,6 +222,68 @@ enum DeckardHooksInstaller {
         ) {
             try? data.write(to: URL(fileURLWithPath: effectiveSettingsPath))
         }
+    }
+
+    /// Remove all Deckard hooks from Claude Code settings and restore the original statusLine.
+    /// Parameters are injectable for testing.
+    static func uninstall(
+        settingsPath: String? = nil,
+        originalStatusLinePath: String? = nil,
+        hooksDirPath: String? = nil
+    ) {
+        let effectiveSettingsPath = settingsPath ?? Self.settingsPath
+        let effectiveOriginalPath = originalStatusLinePath ?? Self.originalStatusLinePath
+        let effectiveHooksDir = hooksDirPath ?? Self.hooksDirPath
+        let fm = FileManager.default
+
+        // Read current settings
+        guard let data = fm.contents(atPath: effectiveSettingsPath),
+              var settings = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return
+        }
+
+        // Restore or remove statusLine
+        if let origData = fm.contents(atPath: effectiveOriginalPath),
+           let original = try? JSONSerialization.jsonObject(with: origData) as? [String: Any] {
+            settings["statusLine"] = original
+        } else {
+            settings.removeValue(forKey: "statusLine")
+        }
+
+        // Remove Deckard hook entries from all events, preserving non-Deckard hooks
+        if var hooks = settings["hooks"] as? [String: Any] {
+            for (eventName, value) in hooks {
+                guard var entries = value as? [[String: Any]] else { continue }
+                entries.removeAll { entry in
+                    guard let entryHooks = entry["hooks"] as? [[String: Any]] else { return false }
+                    return entryHooks.contains { hook in
+                        (hook["command"] as? String)?.contains(".deckard/hooks/") == true
+                    }
+                }
+                if entries.isEmpty {
+                    hooks.removeValue(forKey: eventName)
+                } else {
+                    hooks[eventName] = entries
+                }
+            }
+            if hooks.isEmpty {
+                settings.removeValue(forKey: "hooks")
+            } else {
+                settings["hooks"] = hooks
+            }
+        }
+
+        // Write back
+        if let writeData = try? JSONSerialization.data(
+            withJSONObject: settings,
+            options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        ) {
+            try? writeData.write(to: URL(fileURLWithPath: effectiveSettingsPath))
+        }
+
+        // Clean up hooks directory and saved original
+        try? fm.removeItem(atPath: effectiveHooksDir)
+        try? fm.removeItem(atPath: effectiveOriginalPath)
     }
 
     private static func saveOriginalStatusLine(_ config: [String: Any], to path: String) {

--- a/Sources/App/DeckardHooksInstaller.swift
+++ b/Sources/App/DeckardHooksInstaller.swift
@@ -40,13 +40,20 @@ enum DeckardHooksInstaller {
         """
 
     /// StatusLine script — receives the full /status JSON on stdin (which includes
-    /// rate_limits), extracts the quota data, and sends it to Deckard's control socket.
-    /// Its stdout is ignored (empty) so it doesn't affect Claude Code's status line.
+    /// rate_limits), extracts the quota data, sends it to Deckard's control socket,
+    /// then delegates to the user's original statusline command (if any).
     private static let statusLineScript = """
         #!/bin/sh
-        [ -z "$DECKARD_SOCKET_PATH" ] && exit 0
-        _PY=$(mktemp)
-        cat > "$_PY" << 'PYEOF'
+        # Deckard statusline wrapper — extracts quota data for Deckard,
+        # then delegates to the user's original statusline command (if any).
+
+        # Read stdin into a variable (the /status JSON from Claude Code)
+        INPUT=$(cat)
+
+        # --- Deckard quota extraction (silent no-op if Deckard isn't running) ---
+        if [ -n "$DECKARD_SOCKET_PATH" ]; then
+            _PY=$(mktemp)
+            cat > "$_PY" << 'PYEOF'
         import json,sys,socket,os
         try:
             d=json.loads(sys.stdin.read());rl=d.get("rate_limits",{})
@@ -67,8 +74,19 @@ enum DeckardHooksInstaller {
             sock.close()
         except:pass
         PYEOF
-        python3 "$_PY"
-        rm -f "$_PY"
+            printf '%s' "$INPUT" | python3 "$_PY"
+            rm -f "$_PY"
+        fi
+
+        # --- Delegate to user's original statusline (if saved) ---
+        ORIG_CFG="$HOME/.deckard/original-statusline.json"
+        if [ -f "$ORIG_CFG" ]; then
+            ORIG_CMD=$(python3 -c "import json,sys;print(json.load(open(sys.argv[1])).get('command',''))" "$ORIG_CFG" 2>/dev/null)
+            if [ -n "$ORIG_CMD" ]; then
+                printf '%s' "$INPUT" | eval "$ORIG_CMD"
+                exit $?
+            fi
+        fi
         """
 
     private static let hookScriptPath: String = {
@@ -103,12 +121,24 @@ enum DeckardHooksInstaller {
         mergeHooksIntoSettings()
     }
 
-    private static func installHookScript() {
-        let dir = (hookScriptPath as NSString).deletingLastPathComponent
+    static func installHookScript(
+        hookScriptPath: String? = nil,
+        statusLineScriptPath: String? = nil
+    ) {
+        let effectiveHookPath = hookScriptPath ?? Self.hookScriptPath
+        let effectiveStatusLinePath = statusLineScriptPath ?? Self.statusLineScriptPath
+
+        let dir = (effectiveHookPath as NSString).deletingLastPathComponent
         try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
 
+        // Also ensure statusline script dir exists (may differ from hook dir)
+        let statusLineDir = (effectiveStatusLinePath as NSString).deletingLastPathComponent
+        if statusLineDir != dir {
+            try? FileManager.default.createDirectory(atPath: statusLineDir, withIntermediateDirectories: true)
+        }
+
         // Always overwrite to keep the scripts up to date.
-        for (script, path) in [(hookScript, hookScriptPath), (statusLineScript, statusLineScriptPath)] {
+        for (script, path) in [(hookScript, effectiveHookPath), (statusLineScript, effectiveStatusLinePath)] {
             try? script.write(toFile: path, atomically: true, encoding: .utf8)
             try? FileManager.default.setAttributes(
                 [.posixPermissions: 0o755], ofItemAtPath: path)

--- a/Tests/DeckardHooksInstallerTests.swift
+++ b/Tests/DeckardHooksInstallerTests.swift
@@ -115,6 +115,94 @@ final class DeckardHooksInstallerTests: XCTestCase {
         XCTAssertTrue(true, "DeckardHooksInstaller is an enum with static methods")
     }
 
+    // MARK: - Save original statusLine
+
+    func testSaveOriginalStatusLine() throws {
+        let tempDir = NSTemporaryDirectory() + "deckard-hooks-test-\(UUID().uuidString)/"
+        try FileManager.default.createDirectory(atPath: tempDir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(atPath: tempDir) }
+
+        let settingsPath = tempDir + "settings.json"
+        let originalSavePath = tempDir + "original-statusline.json"
+
+        // Settings with a non-Deckard statusLine
+        let initial: [String: Any] = [
+            "statusLine": [
+                "type": "command",
+                "command": "/usr/local/bin/cc-statusline",
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: initial, options: .prettyPrinted)
+        try data.write(to: URL(fileURLWithPath: settingsPath))
+
+        DeckardHooksInstaller.mergeHooksIntoSettings(
+            settingsPath: settingsPath,
+            originalStatusLinePath: originalSavePath
+        )
+
+        // Verify original was saved
+        let savedData = try Data(contentsOf: URL(fileURLWithPath: originalSavePath))
+        let saved = try JSONSerialization.jsonObject(with: savedData) as! [String: Any]
+        XCTAssertEqual(saved["command"] as? String, "/usr/local/bin/cc-statusline")
+        XCTAssertEqual(saved["type"] as? String, "command")
+    }
+
+    func testDoesNotOverwriteSavedOriginalWhenDeckardScript() throws {
+        let tempDir = NSTemporaryDirectory() + "deckard-hooks-test-\(UUID().uuidString)/"
+        try FileManager.default.createDirectory(atPath: tempDir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(atPath: tempDir) }
+
+        let settingsPath = tempDir + "settings.json"
+        let originalSavePath = tempDir + "original-statusline.json"
+
+        // Pre-save an original
+        let originalConfig: [String: Any] = ["type": "command", "command": "/usr/local/bin/cc-statusline"]
+        let origData = try JSONSerialization.data(withJSONObject: originalConfig, options: .prettyPrinted)
+        try origData.write(to: URL(fileURLWithPath: originalSavePath))
+
+        // Settings already have Deckard's script
+        let settings: [String: Any] = [
+            "statusLine": [
+                "type": "command",
+                "command": NSHomeDirectory() + "/.deckard/hooks/statusline.sh",
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: settings, options: .prettyPrinted)
+        try data.write(to: URL(fileURLWithPath: settingsPath))
+
+        DeckardHooksInstaller.mergeHooksIntoSettings(
+            settingsPath: settingsPath,
+            originalStatusLinePath: originalSavePath
+        )
+
+        // Original should still point to cc-statusline, not overwritten
+        let savedData = try Data(contentsOf: URL(fileURLWithPath: originalSavePath))
+        let saved = try JSONSerialization.jsonObject(with: savedData) as! [String: Any]
+        XCTAssertEqual(saved["command"] as? String, "/usr/local/bin/cc-statusline")
+    }
+
+    func testNoOriginalSavedWhenNoStatusLine() throws {
+        let tempDir = NSTemporaryDirectory() + "deckard-hooks-test-\(UUID().uuidString)/"
+        try FileManager.default.createDirectory(atPath: tempDir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(atPath: tempDir) }
+
+        let settingsPath = tempDir + "settings.json"
+        let originalSavePath = tempDir + "original-statusline.json"
+
+        // Settings with no statusLine
+        let initial: [String: Any] = ["allowedTools": ["Read"]]
+        let data = try JSONSerialization.data(withJSONObject: initial, options: .prettyPrinted)
+        try data.write(to: URL(fileURLWithPath: settingsPath))
+
+        DeckardHooksInstaller.mergeHooksIntoSettings(
+            settingsPath: settingsPath,
+            originalStatusLinePath: originalSavePath
+        )
+
+        // No original should be saved
+        XCTAssertFalse(FileManager.default.fileExists(atPath: originalSavePath))
+    }
+
     // MARK: - Script content markers
 
     func testHookScriptExpectedMarkers() {

--- a/Tests/DeckardHooksInstallerTests.swift
+++ b/Tests/DeckardHooksInstallerTests.swift
@@ -203,6 +203,27 @@ final class DeckardHooksInstallerTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: originalSavePath))
     }
 
+    // MARK: - StatusLine script delegation
+
+    func testStatusLineScriptDelegatesToOriginal() throws {
+        // Verify the statusLine script contains the delegation marker
+        // We test this by checking the installed script file content
+        let tempDir = NSTemporaryDirectory() + "deckard-hooks-test-\(UUID().uuidString)/"
+        let hooksDir = tempDir + "hooks/"
+        try FileManager.default.createDirectory(atPath: hooksDir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(atPath: tempDir) }
+
+        let scriptPath = hooksDir + "statusline.sh"
+        DeckardHooksInstaller.installHookScript(
+            hookScriptPath: scriptPath,
+            statusLineScriptPath: scriptPath  // reuse path, we just need to check content
+        )
+
+        let content = try String(contentsOfFile: scriptPath, encoding: .utf8)
+        XCTAssertTrue(content.contains("original-statusline.json"), "Script should reference original statusline config")
+        XCTAssertTrue(content.contains("ORIG_CMD"), "Script should extract and run original command")
+    }
+
     // MARK: - Script content markers
 
     func testHookScriptExpectedMarkers() {

--- a/Tests/DeckardHooksInstallerTests.swift
+++ b/Tests/DeckardHooksInstallerTests.swift
@@ -324,6 +324,77 @@ final class DeckardHooksInstallerTests: XCTestCase {
         XCTAssertNotNil(restoredSettings["allowedTools"])
     }
 
+    // MARK: - Round-trip with cc-statusline config
+
+    func testRoundTripPreservesCcStatusLineConfig() throws {
+        let tempDir = NSTemporaryDirectory() + "deckard-hooks-test-\(UUID().uuidString)/"
+        let hooksDir = tempDir + "hooks/"
+        try FileManager.default.createDirectory(atPath: hooksDir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(atPath: tempDir) }
+
+        let settingsPath = tempDir + "settings.json"
+        let originalSavePath = tempDir + "original-statusline.json"
+
+        // Simulate cc-statusline's real configuration (relative path + padding field)
+        let initial: [String: Any] = [
+            "allowedTools": ["Read", "Write"],
+            "statusLine": [
+                "type": "command",
+                "command": ".claude/statusline.sh",
+                "padding": 0,
+            ] as [String: Any],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: initial, options: .prettyPrinted)
+        try data.write(to: URL(fileURLWithPath: settingsPath))
+
+        // Step 1: Deckard install — should save original and overwrite
+        DeckardHooksInstaller.mergeHooksIntoSettings(
+            settingsPath: settingsPath,
+            originalStatusLinePath: originalSavePath
+        )
+
+        // Verify original was saved with ALL fields (including padding)
+        let savedData = try Data(contentsOf: URL(fileURLWithPath: originalSavePath))
+        let saved = try JSONSerialization.jsonObject(with: savedData) as! [String: Any]
+        XCTAssertEqual(saved["command"] as? String, ".claude/statusline.sh")
+        XCTAssertEqual(saved["type"] as? String, "command")
+        XCTAssertEqual(saved["padding"] as? Int, 0, "Extra fields like padding must be preserved")
+
+        // Verify settings now point to Deckard's script
+        let afterInstall = try JSONSerialization.jsonObject(
+            with: Data(contentsOf: URL(fileURLWithPath: settingsPath))) as! [String: Any]
+        let installedStatusLine = afterInstall["statusLine"] as! [String: Any]
+        XCTAssertTrue((installedStatusLine["command"] as! String).contains(".deckard/hooks/"))
+
+        // Step 2: Deckard install again — should NOT overwrite saved original
+        DeckardHooksInstaller.mergeHooksIntoSettings(
+            settingsPath: settingsPath,
+            originalStatusLinePath: originalSavePath
+        )
+        let savedAgain = try JSONSerialization.jsonObject(
+            with: Data(contentsOf: URL(fileURLWithPath: originalSavePath))) as! [String: Any]
+        XCTAssertEqual(savedAgain["command"] as? String, ".claude/statusline.sh",
+                       "Re-running install must not overwrite the saved original")
+
+        // Step 3: Uninstall — should restore cc-statusline config exactly
+        DeckardHooksInstaller.uninstall(
+            settingsPath: settingsPath,
+            originalStatusLinePath: originalSavePath,
+            hooksDirPath: hooksDir
+        )
+
+        let restored = try JSONSerialization.jsonObject(
+            with: Data(contentsOf: URL(fileURLWithPath: settingsPath))) as! [String: Any]
+        let restoredStatusLine = restored["statusLine"] as! [String: Any]
+        XCTAssertEqual(restoredStatusLine["command"] as? String, ".claude/statusline.sh")
+        XCTAssertEqual(restoredStatusLine["type"] as? String, "command")
+        XCTAssertEqual(restoredStatusLine["padding"] as? Int, 0,
+                       "Restored config must include all original fields like padding")
+
+        // Other settings untouched
+        XCTAssertNotNil(restored["allowedTools"])
+    }
+
     // MARK: - Script content markers
 
     func testHookScriptExpectedMarkers() {

--- a/Tests/DeckardHooksInstallerTests.swift
+++ b/Tests/DeckardHooksInstallerTests.swift
@@ -224,6 +224,106 @@ final class DeckardHooksInstallerTests: XCTestCase {
         XCTAssertTrue(content.contains("ORIG_CMD"), "Script should extract and run original command")
     }
 
+    // MARK: - Uninstall
+
+    func testUninstallRestoresOriginalStatusLine() throws {
+        let tempDir = NSTemporaryDirectory() + "deckard-hooks-test-\(UUID().uuidString)/"
+        let hooksDir = tempDir + "hooks/"
+        try FileManager.default.createDirectory(atPath: hooksDir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(atPath: tempDir) }
+
+        let settingsPath = tempDir + "settings.json"
+        let originalSavePath = tempDir + "original-statusline.json"
+
+        // Save an original
+        let originalConfig: [String: Any] = ["type": "command", "command": "/usr/local/bin/cc-statusline"]
+        let origData = try JSONSerialization.data(withJSONObject: originalConfig, options: .prettyPrinted)
+        try origData.write(to: URL(fileURLWithPath: originalSavePath))
+
+        // Settings with Deckard's hooks and statusLine
+        let settings: [String: Any] = [
+            "allowedTools": ["Read"],
+            "statusLine": ["type": "command", "command": "~/.deckard/hooks/statusline.sh"],
+            "hooks": [
+                "SessionStart": [
+                    [
+                        "matcher": "",
+                        "hooks": [["type": "command", "command": "~/.deckard/hooks/notify.sh session-start", "timeout": 10]],
+                    ],
+                    [
+                        "matcher": "",
+                        "hooks": [["type": "command", "command": "/other/tool start", "timeout": 5]],
+                    ],
+                ],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: settings, options: .prettyPrinted)
+        try data.write(to: URL(fileURLWithPath: settingsPath))
+
+        // Create dummy hook scripts so hooksDir is non-empty
+        try "#!/bin/sh".write(toFile: hooksDir + "notify.sh", atomically: true, encoding: .utf8)
+
+        DeckardHooksInstaller.uninstall(
+            settingsPath: settingsPath,
+            originalStatusLinePath: originalSavePath,
+            hooksDirPath: hooksDir
+        )
+
+        // Verify original statusLine was restored
+        let restored = try Data(contentsOf: URL(fileURLWithPath: settingsPath))
+        let restoredSettings = try JSONSerialization.jsonObject(with: restored) as! [String: Any]
+        let restoredStatusLine = restoredSettings["statusLine"] as! [String: Any]
+        XCTAssertEqual(restoredStatusLine["command"] as? String, "/usr/local/bin/cc-statusline")
+
+        // Verify Deckard hooks were removed but other hooks preserved
+        let restoredHooks = restoredSettings["hooks"] as! [String: Any]
+        let sessionStartEntries = restoredHooks["SessionStart"] as! [[String: Any]]
+        XCTAssertEqual(sessionStartEntries.count, 1)
+        let remainingHook = (sessionStartEntries[0]["hooks"] as! [[String: Any]])[0]
+        XCTAssertTrue((remainingHook["command"] as! String).contains("/other/tool"))
+
+        // Verify allowedTools untouched
+        XCTAssertNotNil(restoredSettings["allowedTools"])
+
+        // Verify hooks dir was removed
+        XCTAssertFalse(FileManager.default.fileExists(atPath: hooksDir))
+
+        // Verify saved original file was also cleaned up
+        XCTAssertFalse(FileManager.default.fileExists(atPath: originalSavePath))
+    }
+
+    func testUninstallRemovesStatusLineWhenNoOriginal() throws {
+        let tempDir = NSTemporaryDirectory() + "deckard-hooks-test-\(UUID().uuidString)/"
+        try FileManager.default.createDirectory(atPath: tempDir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(atPath: tempDir) }
+
+        let settingsPath = tempDir + "settings.json"
+        let originalSavePath = tempDir + "original-statusline.json"
+        let hooksDir = tempDir + "hooks/"
+
+        // Settings with Deckard's statusLine, no saved original
+        let settings: [String: Any] = [
+            "allowedTools": ["Read"],
+            "statusLine": ["type": "command", "command": "~/.deckard/hooks/statusline.sh"],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: settings, options: .prettyPrinted)
+        try data.write(to: URL(fileURLWithPath: settingsPath))
+
+        DeckardHooksInstaller.uninstall(
+            settingsPath: settingsPath,
+            originalStatusLinePath: originalSavePath,
+            hooksDirPath: hooksDir
+        )
+
+        let restored = try Data(contentsOf: URL(fileURLWithPath: settingsPath))
+        let restoredSettings = try JSONSerialization.jsonObject(with: restored) as! [String: Any]
+
+        // statusLine should be removed entirely
+        XCTAssertNil(restoredSettings["statusLine"])
+        // Other settings preserved
+        XCTAssertNotNil(restoredSettings["allowedTools"])
+    }
+
     // MARK: - Script content markers
 
     func testHookScriptExpectedMarkers() {


### PR DESCRIPTION
## Summary

- Save the user's existing `statusLine` config (e.g. [cc-statusline](https://github.com/chongdashu/cc-statusline)) to `~/.deckard/original-statusline.json` before overwriting it with Deckard's own script
- Update the wrapper `statusline.sh` to chain both: quota data flows to Deckard via socket, then the original statusline command runs with the same stdin
- Add `uninstall()` method that restores the original `statusLine` and removes all Deckard hooks from `settings.json`

## Test plan

- [x] 189 unit tests pass (7 new tests for this feature)
- [x] Round-trip test with realistic cc-statusline config (relative path + `padding` field)
- [x] Verified: original saved on first install, not overwritten on re-install, fully restored on uninstall
- [ ] Manual: launch with fake custom statusLine, verify `original-statusline.json` created
- [ ] Manual: verify quota display still works in sidebar

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)