### PR TITLE
feat: add per-session Claude Code argument customization

### DIFF
--- a/Sources/Window/DeckardWindowController.swift
+++ b/Sources/Window/DeckardWindowController.swift
@@ -581,7 +581,7 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
 
     // MARK: - Tab Management (within a project)
 
-    func createTabInProject(_ project: ProjectItem, isClaude: Bool, name: String? = nil, sessionIdToResume: String? = nil, tmuxSessionToResume: String? = nil) {
+    func createTabInProject(_ project: ProjectItem, isClaude: Bool, name: String? = nil, sessionIdToResume: String? = nil, tmuxSessionToResume: String? = nil, extraArgs: String? = nil) {
         let surface = TerminalSurface()
         let tabName: String
         if let name = name {
@@ -610,8 +610,8 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
 
         let initialInput: String?
         if isClaude {
-            let extraArgs = UserDefaults.standard.string(forKey: "claudeExtraArgs") ?? ""
-            let extraArgsSuffix = extraArgs.isEmpty ? "" : " \(extraArgs)"
+            let resolvedArgs = extraArgs ?? UserDefaults.standard.string(forKey: "claudeExtraArgs") ?? ""
+            let extraArgsSuffix = resolvedArgs.isEmpty ? "" : " \(resolvedArgs)"
             var claudeArgs = extraArgsSuffix
             if let sessionIdToResume {
                 let encoded = project.path.replacingOccurrences(of: "/", with: "-")
@@ -661,7 +661,29 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
             return
         }
         let project = projects[selectedProjectIndex]
-        createTabInProject(project, isClaude: isClaude)
+
+        if isClaude && UserDefaults.standard.bool(forKey: "promptForSessionArgs") {
+            promptForClaudeArgs { [weak self] args in
+                guard let self else { return }
+                guard let args else {
+                    // User cancelled
+                    self.isCreatingTab = false
+                    return
+                }
+                guard self.projects.contains(where: { $0 === project }) else {
+                    self.isCreatingTab = false
+                    return
+                }
+                self.createTabInProject(project, isClaude: true, extraArgs: args)
+                self.finalizeTabCreation(in: project)
+            }
+        } else {
+            createTabInProject(project, isClaude: isClaude)
+            finalizeTabCreation(in: project)
+        }
+    }
+
+    private func finalizeTabCreation(in project: ProjectItem) {
         project.selectedTabIndex = project.tabs.count - 1
         rebuildTabBar()
         rebuildSidebar()
@@ -670,6 +692,33 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
             self?.isCreatingTab = false
+        }
+    }
+
+    private func promptForClaudeArgs(completion: @escaping (String?) -> Void) {
+        let alert = NSAlert()
+        alert.messageText = "Claude Code Arguments"
+        alert.informativeText = "Arguments passed to this session:"
+        alert.addButton(withTitle: "Start")
+        alert.addButton(withTitle: "Cancel")
+
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 300, height: 24))
+        field.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        field.stringValue = UserDefaults.standard.string(forKey: "claudeExtraArgs") ?? ""
+        field.placeholderString = "--permission-mode auto"
+        alert.accessoryView = field
+
+        guard let window else {
+            completion(nil)
+            return
+        }
+
+        alert.beginSheetModal(for: window) { response in
+            if response == .alertFirstButtonReturn {
+                completion(field.stringValue)
+            } else {
+                completion(nil)
+            }
         }
     }
 

--- a/Sources/Window/SettingsWindow.swift
+++ b/Sources/Window/SettingsWindow.swift
@@ -140,6 +140,16 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSTextFie
         extraArgsHelp.textColor = .secondaryLabelColor
         grid.addRow(with: [NSGridCell.emptyContentView, extraArgsHelp])
 
+        // Per-session args checkbox
+        let perSessionCheck = NSButton(checkboxWithTitle: "Customize arguments per session", target: self, action: #selector(perSessionArgsToggled(_:)))
+        perSessionCheck.state = UserDefaults.standard.bool(forKey: "promptForSessionArgs") ? .on : .off
+        grid.addRow(with: [NSGridCell.emptyContentView, perSessionCheck])
+
+        let perSessionHelp = NSTextField(labelWithString: "Show a dialog to set arguments when creating a new Claude tab.")
+        perSessionHelp.font = .systemFont(ofSize: 11)
+        perSessionHelp.textColor = .secondaryLabelColor
+        grid.addRow(with: [NSGridCell.emptyContentView, perSessionHelp])
+
         // Spacer
         let spacer = NSView()
         spacer.translatesAutoresizingMaskIntoConstraints = false
@@ -178,6 +188,10 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSTextFie
         ])
 
         return pane
+    }
+
+    @objc private func perSessionArgsToggled(_ sender: NSButton) {
+        UserDefaults.standard.set(sender.state == .on, forKey: "promptForSessionArgs")
     }
 
     @objc private func vibrancyToggled(_ sender: NSButton) {


### PR DESCRIPTION
## Summary

- Adds a **"Customize arguments per session"** checkbox in Settings > General
- When enabled, creating a new Claude tab shows a dialog to customize CLI arguments for that specific session
- The dialog is pre-filled with the global "Extra arguments" setting as the default
- When disabled (default), behavior is unchanged — sessions use global args silently

See https://github.com/gi11es/deckard/issues/46

## Changes

### `Sources/Window/DeckardWindowController.swift`
- `createTabInProject` gains an optional `extraArgs: String?` parameter — when provided, uses it instead of reading from global `UserDefaults`
- `addTabToCurrentProject` now checks the `promptForSessionArgs` setting; when enabled and creating a Claude tab, shows the args dialog before creating the tab
- Extracted `finalizeTabCreation(in:)` to avoid duplicating tab setup logic between sync and async paths
- Added `promptForClaudeArgs(completion:)` — shows an `NSAlert` sheet with a text field for editing args
- Proper guards: weak self capture, project existence check after async dialog, cancellation handling

### `Sources/Window/SettingsWindow.swift`
- Added "Customize arguments per session" checkbox after the "Extra arguments" field
- Added help text: "Show a dialog to set arguments when creating a new Claude tab."
- Added `perSessionArgsToggled(_:)` handler to persist the setting

## Screenshots

**Settings pane with the new checkbox:**

<img width="756" alt="Settings pane showing Customize arguments per session checkbox" src="https://github.com/user-attachments/assets/8cba7c93-42f2-4650-a111-54cc36d9810d" />

**Dialog shown when creating a new Claude tab:**

<img width="756" alt="Claude Code Arguments dialog" src="https://github.com/user-attachments/assets/7748789c-9275-4194-af25-0fb4f9312f1e" />

## Test plan

- [ ] Enable "Customize arguments per session" in Settings > General
- [ ] Create a new Claude tab — dialog should appear with global args pre-filled
- [ ] Edit the args and click "Start" — session should launch with custom args
- [ ] Click "Cancel" — no tab should be created
- [ ] Disable the checkbox — new Claude tabs should launch without the dialog
- [ ] Create a terminal tab — no dialog should appear regardless of setting
- [ ] Set global args in Settings, create new Claude tab — dialog should show global args as default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
