### PR TITLE
fix: resolve symlinks when looking up Claude session files

### DIFF
--- a/Sources/Detection/ContextMonitor.swift
+++ b/Sources/Detection/ContextMonitor.swift
@@ -34,7 +34,8 @@ class ContextMonitor {
 
     /// Lists all Claude sessions for a project, sorted by most recent first.
     func listSessions(forProjectPath projectPath: String) -> [SessionInfo] {
-        let encoded = projectPath.replacingOccurrences(of: "/", with: "-")
+        let resolved = (projectPath as NSString).resolvingSymlinksInPath
+        let encoded = resolved.replacingOccurrences(of: "/", with: "-")
         let dir = NSHomeDirectory() + "/.claude/projects/\(encoded)"
         let fm = FileManager.default
 
@@ -93,7 +94,8 @@ class ContextMonitor {
     /// Get context usage for a session by reading its JSONL file.
     /// Only reads the tail of the file to find the most recent usage entry.
     func getUsage(sessionId: String, projectPath: String) -> ContextUsage? {
-        let encoded = projectPath.replacingOccurrences(of: "/", with: "-")
+        let resolved = (projectPath as NSString).resolvingSymlinksInPath
+        let encoded = resolved.replacingOccurrences(of: "/", with: "-")
         let jsonlPath = NSHomeDirectory() + "/.claude/projects/\(encoded)/\(sessionId).jsonl"
 
         guard let fh = FileHandle(forReadingAtPath: jsonlPath) else { return nil }

--- a/Sources/Detection/ContextMonitor.swift
+++ b/Sources/Detection/ContextMonitor.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+extension String {
+    /// Encodes a project path into the directory name Claude Code uses under `~/.claude/projects/`.
+    /// Resolves symlinks first so the encoded name matches the canonical path the CLI uses.
+    var claudeProjectDirName: String {
+        (self as NSString).resolvingSymlinksInPath.replacingOccurrences(of: "/", with: "-")
+    }
+}
+
 /// Reads Claude Code session JSONL files to calculate context usage.
 class ContextMonitor {
     static let shared = ContextMonitor()
@@ -34,8 +42,7 @@ class ContextMonitor {
 
     /// Lists all Claude sessions for a project, sorted by most recent first.
     func listSessions(forProjectPath projectPath: String) -> [SessionInfo] {
-        let resolved = (projectPath as NSString).resolvingSymlinksInPath
-        let encoded = resolved.replacingOccurrences(of: "/", with: "-")
+        let encoded = projectPath.claudeProjectDirName
         let dir = NSHomeDirectory() + "/.claude/projects/\(encoded)"
         let fm = FileManager.default
 
@@ -94,8 +101,7 @@ class ContextMonitor {
     /// Get context usage for a session by reading its JSONL file.
     /// Only reads the tail of the file to find the most recent usage entry.
     func getUsage(sessionId: String, projectPath: String) -> ContextUsage? {
-        let resolved = (projectPath as NSString).resolvingSymlinksInPath
-        let encoded = resolved.replacingOccurrences(of: "/", with: "-")
+        let encoded = projectPath.claudeProjectDirName
         let jsonlPath = NSHomeDirectory() + "/.claude/projects/\(encoded)/\(sessionId).jsonl"
 
         guard let fh = FileHandle(forReadingAtPath: jsonlPath) else { return nil }

--- a/Sources/Detection/QuotaMonitor.swift
+++ b/Sources/Detection/QuotaMonitor.swift
@@ -112,7 +112,8 @@ class QuotaMonitor {
         var bestDate: Date = .distantPast
 
         for projectPath in projectPaths {
-            let encoded = projectPath.replacingOccurrences(of: "/", with: "-")
+            let resolved = (projectPath as NSString).resolvingSymlinksInPath
+            let encoded = resolved.replacingOccurrences(of: "/", with: "-")
             let dir = NSHomeDirectory() + "/.claude/projects/\(encoded)"
 
             guard let files = try? fm.contentsOfDirectory(atPath: dir) else { continue }

--- a/Sources/Detection/QuotaMonitor.swift
+++ b/Sources/Detection/QuotaMonitor.swift
@@ -112,8 +112,7 @@ class QuotaMonitor {
         var bestDate: Date = .distantPast
 
         for projectPath in projectPaths {
-            let resolved = (projectPath as NSString).resolvingSymlinksInPath
-            let encoded = resolved.replacingOccurrences(of: "/", with: "-")
+            let encoded = projectPath.claudeProjectDirName
             let dir = NSHomeDirectory() + "/.claude/projects/\(encoded)"
 
             guard let files = try? fm.contentsOfDirectory(atPath: dir) else { continue }

--- a/Sources/Window/DeckardWindowController.swift
+++ b/Sources/Window/DeckardWindowController.swift
@@ -618,7 +618,7 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
             let extraArgsSuffix = extraArgs.isEmpty ? "" : " \(extraArgs)"
             var claudeArgs = extraArgsSuffix
             if let sessionIdToResume {
-                let encoded = project.path.replacingOccurrences(of: "/", with: "-")
+                let encoded = project.path.claudeProjectDirName
                 let jsonlPath = NSHomeDirectory() + "/.claude/projects/\(encoded)/\(sessionIdToResume).jsonl"
                 if FileManager.default.fileExists(atPath: jsonlPath) {
                     claudeArgs = " --resume \(sessionIdToResume)\(extraArgsSuffix)"


### PR DESCRIPTION
## Summary

- When a project is added via a symlink (e.g. `~/obsidian` -> iCloud Drive vault), Deckard stores the literal symlink path, but Claude Code CLI resolves symlinks before creating session directories. The path mismatch causes `ContextMonitor` and `QuotaMonitor` to miss session JSONL files, so model/context info is missing from the sidebar.
- Adds `NSString.resolvingSymlinksInPath` at the three sites where project paths are encoded to directory names: `listSessions`, `getUsage`, and `computeTokenRate`.
- No changes to `ProjectItem.path`, sidebar display, or persistence.

Fixes #45

## Test plan

- [ ] Add a project via a symlink path (e.g. `~/obsidian` pointing to an iCloud Drive vault)
- [ ] Start a Claude Code session in that project
- [ ] Verify model name, context usage, and token rate appear in the sidebar
- [ ] Verify projects added via non-symlink paths still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)