### PR TITLE
feat: replace Resume Session menu with Explore Sessions window

### DIFF
--- a/Deckard.xcodeproj/project.pbxproj
+++ b/Deckard.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		QA200004QA200004QA200004 /* QuotaView.swift in Sources */ = {isa = PBXBuildFile; fileRef = QA200003QA200003QA200003 /* QuotaView.swift */; };
 		QA200006QA200006QA200006 /* QuotaMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = QA200005QA200005QA200005 /* QuotaMonitorTests.swift */; };
 		SE000001SE000001SE000001 /* SessionExplorerModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE000002SE000002SE000002 /* SessionExplorerModels.swift */; };
+		SE000003SE000003SE000003 /* BookmarkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE000004SE000004SE000004 /* BookmarkManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -116,6 +117,7 @@
 		QA200003QA200003QA200003 /* QuotaView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuotaView.swift; sourceTree = "<group>"; };
 		QA200005QA200005QA200005 /* QuotaMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuotaMonitorTests.swift; sourceTree = "<group>"; };
 		SE000002SE000002SE000002 /* SessionExplorerModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionExplorerModels.swift; sourceTree = "<group>"; };
+		SE000004SE000004SE000004 /* BookmarkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -214,6 +216,7 @@
 			children = (
 				7BE2AA0719D32ACCD1549184 /* SessionState.swift */,
 				SE000002SE000002SE000002 /* SessionExplorerModels.swift */,
+				SE000004SE000004SE000004 /* BookmarkManager.swift */,
 			);
 			path = Session;
 			sourceTree = "<group>";
@@ -425,6 +428,7 @@
 				QA200002QA200002QA200002 /* QuotaMonitor.swift in Sources */,
 				QA200004QA200004QA200004 /* QuotaView.swift in Sources */,
 				SE000001SE000001SE000001 /* SessionExplorerModels.swift in Sources */,
+				SE000003SE000003SE000003 /* BookmarkManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Deckard.xcodeproj/project.pbxproj
+++ b/Deckard.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		QA200002QA200002QA200002 /* QuotaMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = QA200001QA200001QA200001 /* QuotaMonitor.swift */; };
 		QA200004QA200004QA200004 /* QuotaView.swift in Sources */ = {isa = PBXBuildFile; fileRef = QA200003QA200003QA200003 /* QuotaView.swift */; };
 		QA200006QA200006QA200006 /* QuotaMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = QA200005QA200005QA200005 /* QuotaMonitorTests.swift */; };
+		SE000001SE000001SE000001 /* SessionExplorerModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE000002SE000002SE000002 /* SessionExplorerModels.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -114,6 +115,7 @@
 		QA200001QA200001QA200001 /* QuotaMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuotaMonitor.swift; sourceTree = "<group>"; };
 		QA200003QA200003QA200003 /* QuotaView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuotaView.swift; sourceTree = "<group>"; };
 		QA200005QA200005QA200005 /* QuotaMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuotaMonitorTests.swift; sourceTree = "<group>"; };
+		SE000002SE000002SE000002 /* SessionExplorerModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionExplorerModels.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -211,6 +213,7 @@
 			isa = PBXGroup;
 			children = (
 				7BE2AA0719D32ACCD1549184 /* SessionState.swift */,
+				SE000002SE000002SE000002 /* SessionExplorerModels.swift */,
 			);
 			path = Session;
 			sourceTree = "<group>";
@@ -421,6 +424,7 @@
 				DD440001DD440001DD440001 /* CrashReporter.swift in Sources */,
 				QA200002QA200002QA200002 /* QuotaMonitor.swift in Sources */,
 				QA200004QA200004QA200004 /* QuotaView.swift in Sources */,
+				SE000001SE000001SE000001 /* SessionExplorerModels.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Deckard.xcodeproj/project.pbxproj
+++ b/Deckard.xcodeproj/project.pbxproj
@@ -62,6 +62,8 @@
 		SE000001SE000001SE000001 /* SessionExplorerModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE000002SE000002SE000002 /* SessionExplorerModels.swift */; };
 		SE000003SE000003SE000003 /* BookmarkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE000004SE000004SE000004 /* BookmarkManager.swift */; };
 		SE000005SE000005SE000005 /* SummaryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE000006SE000006SE000006 /* SummaryManager.swift */; };
+		SE000007SE000007SE000007 /* SessionExplorerWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE000008SE000008SE000008 /* SessionExplorerWindowController.swift */; };
+		SE000009SE000009SE000009 /* SessionExplorerTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE00000ASE00000ASE00000A /* SessionExplorerTimelineView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -120,6 +122,8 @@
 		SE000002SE000002SE000002 /* SessionExplorerModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionExplorerModels.swift; sourceTree = "<group>"; };
 		SE000004SE000004SE000004 /* BookmarkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkManager.swift; sourceTree = "<group>"; };
 		SE000006SE000006SE000006 /* SummaryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryManager.swift; sourceTree = "<group>"; };
+		SE000008SE000008SE000008 /* SessionExplorerWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionExplorerWindowController.swift; sourceTree = "<group>"; };
+		SE00000ASE00000ASE00000A /* SessionExplorerTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionExplorerTimelineView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -220,6 +224,8 @@
 				SE000002SE000002SE000002 /* SessionExplorerModels.swift */,
 				SE000004SE000004SE000004 /* BookmarkManager.swift */,
 				SE000006SE000006SE000006 /* SummaryManager.swift */,
+				SE000008SE000008SE000008 /* SessionExplorerWindowController.swift */,
+				SE00000ASE00000ASE00000A /* SessionExplorerTimelineView.swift */,
 			);
 			path = Session;
 			sourceTree = "<group>";
@@ -433,6 +439,8 @@
 				SE000001SE000001SE000001 /* SessionExplorerModels.swift in Sources */,
 				SE000003SE000003SE000003 /* BookmarkManager.swift in Sources */,
 				SE000005SE000005SE000005 /* SummaryManager.swift in Sources */,
+				SE000007SE000007SE000007 /* SessionExplorerWindowController.swift in Sources */,
+				SE000009SE000009SE000009 /* SessionExplorerTimelineView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Deckard.xcodeproj/project.pbxproj
+++ b/Deckard.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		QA200006QA200006QA200006 /* QuotaMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = QA200005QA200005QA200005 /* QuotaMonitorTests.swift */; };
 		SE000001SE000001SE000001 /* SessionExplorerModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE000002SE000002SE000002 /* SessionExplorerModels.swift */; };
 		SE000003SE000003SE000003 /* BookmarkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE000004SE000004SE000004 /* BookmarkManager.swift */; };
+		SE000005SE000005SE000005 /* SummaryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE000006SE000006SE000006 /* SummaryManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -118,6 +119,7 @@
 		QA200005QA200005QA200005 /* QuotaMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuotaMonitorTests.swift; sourceTree = "<group>"; };
 		SE000002SE000002SE000002 /* SessionExplorerModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionExplorerModels.swift; sourceTree = "<group>"; };
 		SE000004SE000004SE000004 /* BookmarkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkManager.swift; sourceTree = "<group>"; };
+		SE000006SE000006SE000006 /* SummaryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -217,6 +219,7 @@
 				7BE2AA0719D32ACCD1549184 /* SessionState.swift */,
 				SE000002SE000002SE000002 /* SessionExplorerModels.swift */,
 				SE000004SE000004SE000004 /* BookmarkManager.swift */,
+				SE000006SE000006SE000006 /* SummaryManager.swift */,
 			);
 			path = Session;
 			sourceTree = "<group>";
@@ -429,6 +432,7 @@
 				QA200004QA200004QA200004 /* QuotaView.swift in Sources */,
 				SE000001SE000001SE000001 /* SessionExplorerModels.swift in Sources */,
 				SE000003SE000003SE000003 /* BookmarkManager.swift in Sources */,
+				SE000005SE000005SE000005 /* SummaryManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Run multiple sessions side by side in a single window with tabs, projects, and s
 - **Project sidebar**: Each open directory gets its own set of tabs, persisted across restarts. Group related projects into collapsible sidebar folders for organization (e.g., by client).
 - **Context & quota tracking**: A progress bar shows context window usage. A sparkline visualizes token rate over time, and rate limit indicators show 5-hour and 7-day quota consumption.
 - **Session state detection**: Tab badges show whether Claude is thinking, waiting for input, needs tool permission, or has errored. Terminal tabs show real-time CPU and disk activity for the foreground process.
+- **Session explorer**: Right-click a project and choose "Explore Sessions" (or press Cmd+Shift+E) to browse all past Claude sessions. View the full conversation timeline, resume or fork from any point, and bookmark favorite sessions with a star toggle. Optionally summarize sessions and per-turn actions with Haiku — summaries are cached and incrementally updated when sessions are continued.
 - **Session persistence**: Claude sessions resume via `--resume`. Tab structure and working directories are preserved across restarts.
 - **486 color themes**: Ships with 486 built-in themes (Ghostty format) and loads custom themes from `~/.config/ghostty/themes`. Search and preview in Settings.
 - **Customizable shortcuts**: All keyboard shortcuts are rebindable in Settings > Shortcuts.

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -201,6 +201,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         newFolderItem.target = self
         fileMenu.addItem(newFolderItem)
 
+        let exploreSessionsItem = NSMenuItem(title: "Explore Sessions", action: #selector(exploreSessions), keyEquivalent: "")
+        exploreSessionsItem.setShortcut(for: .exploreSessions)
+        fileMenu.addItem(exploreSessionsItem)
+
         let closeProjectItem = NSMenuItem(title: "Close Folder", action: #selector(closeCurrentProject), keyEquivalent: "")
         closeProjectItem.setShortcut(for: .closeFolder)
         fileMenu.addItem(closeProjectItem)
@@ -296,6 +300,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
         windowController?.closeCurrentTab()
+    }
+
+    @objc private func exploreSessions() {
+        windowController?.exploreCurrentProjectSessions()
     }
 
     @objc private func closeCurrentProject() {

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -198,8 +198,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         fileMenu.addItem(closeItem)
 
         let newFolderItem = NSMenuItem(title: "New Sidebar Folder", action: #selector(createNewSidebarFolder), keyEquivalent: "")
+        newFolderItem.setShortcut(for: .newSidebarFolder)
         newFolderItem.target = self
         fileMenu.addItem(newFolderItem)
+
+        let moveOutItem = NSMenuItem(title: "Move Out of Folder", action: #selector(moveCurrentProjectOutOfFolder), keyEquivalent: "")
+        moveOutItem.setShortcut(for: .moveOutOfFolder)
+        moveOutItem.target = self
+        fileMenu.addItem(moveOutItem)
 
         let exploreSessionsItem = NSMenuItem(title: "Explore Sessions", action: #selector(exploreSessions), keyEquivalent: "")
         exploreSessionsItem.setShortcut(for: .exploreSessions)
@@ -304,6 +310,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func exploreSessions() {
         windowController?.exploreCurrentProjectSessions()
+    }
+
+    @objc private func moveCurrentProjectOutOfFolder() {
+        windowController?.moveCurrentProjectOutOfFolder()
     }
 
     @objc private func closeCurrentProject() {

--- a/Sources/App/ShortcutNames.swift
+++ b/Sources/App/ShortcutNames.swift
@@ -11,6 +11,7 @@ extension KeyboardShortcuts.Name {
     static let nextProject = Self("nextProject", default: .init(.rightBracket, modifiers: [.command, .option]))
     static let previousProject = Self("previousProject", default: .init(.leftBracket, modifiers: [.command, .option]))
     static let toggleSidebar = Self("toggleSidebar", default: .init(.s, modifiers: [.command, .control]))
+    static let exploreSessions = Self("exploreSessions", default: .init(.e, modifiers: [.command, .shift]))
     static let settings = Self("settings", default: .init(.comma, modifiers: .command))
     static let tab1 = Self("tab1", default: .init(.one, modifiers: .command))
     static let tab2 = Self("tab2", default: .init(.two, modifiers: .command))
@@ -41,6 +42,7 @@ let configurableShortcuts: [ShortcutEntry] = [
     ShortcutEntry(name: .nextProject, label: "Next Project"),
     ShortcutEntry(name: .previousProject, label: "Previous Project"),
     ShortcutEntry(name: .toggleSidebar, label: "Toggle Sidebar"),
+    ShortcutEntry(name: .exploreSessions, label: "Explore Sessions"),
     ShortcutEntry(name: .settings, label: "Settings"),
     ShortcutEntry(name: .tab1, label: "Project 1"),
     ShortcutEntry(name: .tab2, label: "Project 2"),

--- a/Sources/App/ShortcutNames.swift
+++ b/Sources/App/ShortcutNames.swift
@@ -12,6 +12,8 @@ extension KeyboardShortcuts.Name {
     static let previousProject = Self("previousProject", default: .init(.leftBracket, modifiers: [.command, .option]))
     static let toggleSidebar = Self("toggleSidebar", default: .init(.s, modifiers: [.command, .control]))
     static let exploreSessions = Self("exploreSessions", default: .init(.e, modifiers: [.command, .shift]))
+    static let newSidebarFolder = Self("newSidebarFolder", default: .init(.n, modifiers: [.command, .option]))
+    static let moveOutOfFolder = Self("moveOutOfFolder", default: .init(.u, modifiers: [.command, .option]))
     static let settings = Self("settings", default: .init(.comma, modifiers: .command))
     static let tab1 = Self("tab1", default: .init(.one, modifiers: .command))
     static let tab2 = Self("tab2", default: .init(.two, modifiers: .command))
@@ -43,6 +45,8 @@ let configurableShortcuts: [ShortcutEntry] = [
     ShortcutEntry(name: .previousProject, label: "Previous Project"),
     ShortcutEntry(name: .toggleSidebar, label: "Toggle Sidebar"),
     ShortcutEntry(name: .exploreSessions, label: "Explore Sessions"),
+    ShortcutEntry(name: .newSidebarFolder, label: "New Sidebar Folder"),
+    ShortcutEntry(name: .moveOutOfFolder, label: "Move Out of Folder"),
     ShortcutEntry(name: .settings, label: "Settings"),
     ShortcutEntry(name: .tab1, label: "Project 1"),
     ShortcutEntry(name: .tab2, label: "Project 2"),

--- a/Sources/Detection/ContextMonitor.swift
+++ b/Sources/Detection/ContextMonitor.swift
@@ -38,6 +38,7 @@ class ContextMonitor {
         let sessionId: String
         let modificationDate: Date
         let firstUserMessage: String
+        let messageCount: Int
     }
 
     /// Lists all Claude sessions for a project, sorted by most recent first.
@@ -58,44 +59,165 @@ class ContextMonitor {
                   let modDate = attrs[.modificationDate] as? Date else { continue }
 
             var firstMessage = ""
+            var uniqueUserTurns = 0
 
-            if let fh = FileHandle(forReadingAtPath: filePath) {
-                let headData = fh.readData(ofLength: 8192)
-                try? fh.close()
+            if let data = try? Data(contentsOf: URL(fileURLWithPath: filePath)),
+               let fileContent = String(data: data, encoding: .utf8) {
+                var seenPromptIds = Set<String>()
+                let lines = fileContent.components(separatedBy: "\n")
+                for line in lines where !line.isEmpty {
+                    guard let ld = line.data(using: .utf8),
+                          let json = try? JSONSerialization.jsonObject(with: ld) as? [String: Any] else { continue }
 
-                if let headStr = String(data: headData, encoding: .utf8) {
-                    let lines = headStr.components(separatedBy: "\n")
-                    for line in lines where !line.isEmpty {
-                        guard let ld = line.data(using: .utf8),
-                              let json = try? JSONSerialization.jsonObject(with: ld) as? [String: Any] else { continue }
-
-                        let type = json["type"] as? String ?? ""
-                        if type == "user" && firstMessage.isEmpty {
-                            if let msg = json["message"] as? [String: Any] {
-                                if let content = msg["content"] as? String {
-                                    firstMessage = content
-                                } else if let contentArr = msg["content"] as? [[String: Any]] {
-                                    firstMessage = contentArr.first(where: { $0["type"] as? String == "text" })?["text"] as? String ?? ""
-                                }
-                            }
-                            break
+                    let type = json["type"] as? String ?? ""
+                    if type == "user", let promptId = json["promptId"] as? String, !seenPromptIds.contains(promptId) {
+                        let msg = json["message"] as? [String: Any]
+                        var text = ""
+                        if let content = msg?["content"] as? String {
+                            text = content
+                        } else if let contentArr = msg?["content"] as? [[String: Any]] {
+                            text = contentArr.first(where: { $0["type"] as? String == "text" })?["text"] as? String ?? ""
+                        }
+                        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                        guard !trimmed.isEmpty else {
+                            seenPromptIds.insert(promptId)
+                            continue
+                        }
+                        seenPromptIds.insert(promptId)
+                        uniqueUserTurns += 1
+                        if firstMessage.isEmpty {
+                            firstMessage = trimmed.components(separatedBy: "\n").first ?? ""
                         }
                     }
                 }
             }
 
-            firstMessage = firstMessage.components(separatedBy: "\n").first ?? ""
-            firstMessage = firstMessage.trimmingCharacters(in: .whitespacesAndNewlines)
-
             results.append(SessionInfo(
                 sessionId: sessionId,
                 modificationDate: modDate,
-                firstUserMessage: firstMessage
+                firstUserMessage: firstMessage,
+                messageCount: uniqueUserTurns
             ))
         }
 
         results.sort { $0.modificationDate > $1.modificationDate }
         return results
+    }
+
+    /// Parses a session JSONL file and returns an ordered list of user turns.
+    /// Deduplicates by promptId — only the first occurrence with non-empty content is kept.
+    func parseTimeline(sessionId: String, projectPath: String) -> [TimelineEntry] {
+        let encoded = projectPath.claudeProjectDirName
+        let jsonlPath = NSHomeDirectory() + "/.claude/projects/\(encoded)/\(sessionId).jsonl"
+
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: jsonlPath)),
+              let content = String(data: data, encoding: .utf8) else { return [] }
+
+        var entries: [TimelineEntry] = []
+        var seenPromptIds = Set<String>()
+        let iso8601 = ISO8601DateFormatter()
+        iso8601.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        for line in content.components(separatedBy: "\n") where !line.isEmpty {
+            guard let lineData = line.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                  let type = json["type"] as? String, type == "user",
+                  let promptId = json["promptId"] as? String,
+                  !seenPromptIds.contains(promptId) else { continue }
+
+            let msg = json["message"] as? [String: Any]
+            var text = ""
+            if let content = msg?["content"] as? String {
+                text = content
+            } else if let contentArr = msg?["content"] as? [[String: Any]] {
+                text = contentArr.first(where: { $0["type"] as? String == "text" })?["text"] as? String ?? ""
+            }
+
+            // Skip empty continuation messages (same promptId, no content)
+            guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                seenPromptIds.insert(promptId)
+                continue
+            }
+
+            seenPromptIds.insert(promptId)
+
+            let timestamp: Date?
+            if let ts = json["timestamp"] as? String {
+                timestamp = iso8601.date(from: ts)
+            } else {
+                timestamp = nil
+            }
+
+            entries.append(TimelineEntry(
+                index: entries.count,
+                promptId: promptId,
+                message: text.trimmingCharacters(in: .whitespacesAndNewlines),
+                timestamp: timestamp,
+                isBookmarked: false,
+                bookmarkLabel: nil
+            ))
+        }
+
+        return entries
+    }
+
+    /// Creates a truncated copy of a session JSONL, keeping everything up to (and including
+    /// the full response for) the Nth unique user turn. Returns the new session ID.
+    func truncateSession(sessionId: String, projectPath: String, afterTurnIndex: Int) -> String? {
+        let encoded = projectPath.claudeProjectDirName
+        let dir = NSHomeDirectory() + "/.claude/projects/\(encoded)"
+        let jsonlPath = dir + "/\(sessionId).jsonl"
+
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: jsonlPath)),
+              let content = String(data: data, encoding: .utf8) else { return nil }
+
+        let lines = content.components(separatedBy: "\n")
+        var seenPromptIds = Set<String>()
+        var uniqueTurnCount = -1  // will be incremented to 0 on first user turn
+        var cutoffLineIndex = lines.count
+
+        for (i, line) in lines.enumerated() where !line.isEmpty {
+            guard let lineData = line.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                  let type = json["type"] as? String, type == "user",
+                  let promptId = json["promptId"] as? String,
+                  !seenPromptIds.contains(promptId) else { continue }
+
+            // Check if this user message has actual content (not a continuation)
+            let msg = json["message"] as? [String: Any]
+            var text = ""
+            if let c = msg?["content"] as? String { text = c }
+            else if let arr = msg?["content"] as? [[String: Any]] {
+                text = arr.first(where: { $0["type"] as? String == "text" })?["text"] as? String ?? ""
+            }
+            guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                seenPromptIds.insert(promptId)
+                continue
+            }
+
+            seenPromptIds.insert(promptId)
+            uniqueTurnCount += 1
+
+            // When we hit the turn AFTER the one we want, cut here
+            if uniqueTurnCount > afterTurnIndex {
+                cutoffLineIndex = i
+                break
+            }
+        }
+
+        let truncatedLines = lines.prefix(cutoffLineIndex).filter { !$0.isEmpty }
+        let truncatedContent = truncatedLines.joined(separator: "\n") + "\n"
+
+        let newSessionId = UUID().uuidString.lowercased()
+        let newPath = dir + "/\(newSessionId).jsonl"
+
+        guard let writeData = truncatedContent.data(using: .utf8) else { return nil }
+        do {
+            try writeData.write(to: URL(fileURLWithPath: newPath), options: .atomic)
+            return newSessionId
+        } catch {
+            return nil
+        }
     }
 
     /// Get context usage for a session by reading its JSONL file.

--- a/Sources/Detection/ContextMonitor.swift
+++ b/Sources/Detection/ContextMonitor.swift
@@ -180,8 +180,9 @@ class ContextMonitor {
                !seenPromptIds.contains(promptId) {
                 let msg = json["message"] as? [String: Any]
                 var text = ""
-                if let c = msg?["content"] as? String { text = c }
-                else if let arr = msg?["content"] as? [[String: Any]] {
+                if let c = msg?["content"] as? String {
+                    text = c
+                } else if let arr = msg?["content"] as? [[String: Any]] {
                     text = arr.first(where: { $0["type"] as? String == "text" })?["text"] as? String ?? ""
                 }
                 guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {

--- a/Sources/Detection/ContextMonitor.swift
+++ b/Sources/Detection/ContextMonitor.swift
@@ -150,11 +150,71 @@ class ContextMonitor {
                 message: text.trimmingCharacters(in: .whitespacesAndNewlines),
                 timestamp: timestamp,
                 isBookmarked: false,
-                bookmarkLabel: nil
+                bookmarkLabel: nil,
+                actionSummary: nil
             ))
         }
 
         return entries
+    }
+
+    /// Extracts a raw description of tool uses for each user turn in a session.
+    /// Returns a dictionary mapping turn index to a list of action descriptions.
+    func parseActions(sessionId: String, projectPath: String) -> [Int: [String]] {
+        let encoded = projectPath.claudeProjectDirName
+        let jsonlPath = NSHomeDirectory() + "/.claude/projects/\(encoded)/\(sessionId).jsonl"
+
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: jsonlPath)),
+              let content = String(data: data, encoding: .utf8) else { return [:] }
+
+        var result: [Int: [String]] = [:]
+        var currentTurnIndex = -1
+        var seenPromptIds = Set<String>()
+
+        for line in content.components(separatedBy: "\n") where !line.isEmpty {
+            guard let lineData = line.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                  let type = json["type"] as? String else { continue }
+
+            if type == "user", let promptId = json["promptId"] as? String,
+               !seenPromptIds.contains(promptId) {
+                let msg = json["message"] as? [String: Any]
+                var text = ""
+                if let c = msg?["content"] as? String { text = c }
+                else if let arr = msg?["content"] as? [[String: Any]] {
+                    text = arr.first(where: { $0["type"] as? String == "text" })?["text"] as? String ?? ""
+                }
+                guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                    seenPromptIds.insert(promptId)
+                    continue
+                }
+                seenPromptIds.insert(promptId)
+                currentTurnIndex += 1
+            } else if type == "assistant", currentTurnIndex >= 0 {
+                let msg = json["message"] as? [String: Any]
+                let inner = msg?["message"] as? [String: Any] ?? msg
+                guard let contentArr = inner?["content"] as? [[String: Any]] else { continue }
+
+                for block in contentArr {
+                    guard block["type"] as? String == "tool_use",
+                          let name = block["name"] as? String else { continue }
+                    let input = block["input"] as? [String: Any] ?? [:]
+                    var desc = name
+                    if let fp = input["file_path"] as? String {
+                        let filename = (fp as NSString).lastPathComponent
+                        desc = "\(name) \(filename)"
+                    } else if let cmd = input["command"] as? String {
+                        let brief = cmd.components(separatedBy: "\n").first ?? cmd
+                        desc = "\(name): \(String(brief.prefix(50)))"
+                    } else if let pattern = input["pattern"] as? String {
+                        desc = "\(name) \(pattern)"
+                    }
+                    result[currentTurnIndex, default: []].append(desc)
+                }
+            }
+        }
+
+        return result
     }
 
     /// Creates a truncated copy of a session JSONL, keeping everything up to (and including

--- a/Sources/Detection/ContextMonitor.swift
+++ b/Sources/Detection/ContextMonitor.swift
@@ -182,8 +182,9 @@ class ContextMonitor {
             // Check if this user message has actual content (not a continuation)
             let msg = json["message"] as? [String: Any]
             var text = ""
-            if let c = msg?["content"] as? String { text = c }
-            else if let arr = msg?["content"] as? [[String: Any]] {
+            if let c = msg?["content"] as? String {
+                text = c
+            } else if let arr = msg?["content"] as? [[String: Any]] {
                 text = arr.first(where: { $0["type"] as? String == "text" })?["text"] as? String ?? ""
             }
             guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {

--- a/Sources/Detection/ContextMonitor.swift
+++ b/Sources/Detection/ContextMonitor.swift
@@ -59,44 +59,40 @@ class ContextMonitor {
                   let modDate = attrs[.modificationDate] as? Date else { continue }
 
             var firstMessage = ""
-            var uniqueUserTurns = 0
 
-            if let data = try? Data(contentsOf: URL(fileURLWithPath: filePath)),
-               let fileContent = String(data: data, encoding: .utf8) {
-                var seenPromptIds = Set<String>()
-                let lines = fileContent.components(separatedBy: "\n")
-                for line in lines where !line.isEmpty {
-                    guard let ld = line.data(using: .utf8),
-                          let json = try? JSONSerialization.jsonObject(with: ld) as? [String: Any] else { continue }
+            if let fh = FileHandle(forReadingAtPath: filePath) {
+                let headData = fh.readData(ofLength: 8192)
+                try? fh.close()
 
-                    let type = json["type"] as? String ?? ""
-                    if type == "user", let promptId = json["promptId"] as? String, !seenPromptIds.contains(promptId) {
-                        let msg = json["message"] as? [String: Any]
-                        var text = ""
-                        if let content = msg?["content"] as? String {
-                            text = content
-                        } else if let contentArr = msg?["content"] as? [[String: Any]] {
-                            text = contentArr.first(where: { $0["type"] as? String == "text" })?["text"] as? String ?? ""
-                        }
-                        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-                        guard !trimmed.isEmpty else {
-                            seenPromptIds.insert(promptId)
-                            continue
-                        }
-                        seenPromptIds.insert(promptId)
-                        uniqueUserTurns += 1
-                        if firstMessage.isEmpty {
-                            firstMessage = trimmed.components(separatedBy: "\n").first ?? ""
+                if let headStr = String(data: headData, encoding: .utf8) {
+                    let lines = headStr.components(separatedBy: "\n")
+                    for line in lines where !line.isEmpty {
+                        guard let ld = line.data(using: .utf8),
+                              let json = try? JSONSerialization.jsonObject(with: ld) as? [String: Any] else { continue }
+
+                        let type = json["type"] as? String ?? ""
+                        if type == "user" && firstMessage.isEmpty {
+                            if let msg = json["message"] as? [String: Any] {
+                                if let content = msg["content"] as? String {
+                                    firstMessage = content
+                                } else if let contentArr = msg["content"] as? [[String: Any]] {
+                                    firstMessage = contentArr.first(where: { $0["type"] as? String == "text" })?["text"] as? String ?? ""
+                                }
+                            }
+                            break
                         }
                     }
                 }
             }
 
+            firstMessage = firstMessage.components(separatedBy: "\n").first ?? ""
+            firstMessage = firstMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+
             results.append(SessionInfo(
                 sessionId: sessionId,
                 modificationDate: modDate,
                 firstUserMessage: firstMessage,
-                messageCount: uniqueUserTurns
+                messageCount: 0
             ))
         }
 

--- a/Sources/Detection/ContextMonitor.swift
+++ b/Sources/Detection/ContextMonitor.swift
@@ -149,8 +149,6 @@ class ContextMonitor {
                 promptId: promptId,
                 message: text.trimmingCharacters(in: .whitespacesAndNewlines),
                 timestamp: timestamp,
-                isBookmarked: false,
-                bookmarkLabel: nil,
                 actionSummary: nil
             ))
         }

--- a/Sources/Session/BookmarkManager.swift
+++ b/Sources/Session/BookmarkManager.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Manages session bookmarks persisted to ~/Library/Application Support/Deckard/session-bookmarks.json.
+/// Bookmarks are keyed by the encoded project path (matching Claude Code's convention).
+class BookmarkManager {
+    static let shared = BookmarkManager()
+
+    private let fileURL: URL = {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let deckardDir = appSupport.appendingPathComponent("Deckard")
+        try? FileManager.default.createDirectory(at: deckardDir, withIntermediateDirectories: true)
+        return deckardDir.appendingPathComponent("session-bookmarks.json")
+    }()
+
+    private var cache: [String: [SessionBookmark]]?
+
+    /// Returns all bookmarks for a given project path.
+    func bookmarks(forProjectPath projectPath: String) -> [SessionBookmark] {
+        let all = loadAll()
+        let key = projectPath.claudeProjectDirName
+        return all[key] ?? []
+    }
+
+    /// Adds a bookmark. Returns the created bookmark.
+    @discardableResult
+    func addBookmark(projectPath: String, sessionId: String, messageIndex: Int, label: String) -> SessionBookmark {
+        var all = loadAll()
+        let key = projectPath.claudeProjectDirName
+        var projectBookmarks = all[key] ?? []
+
+        let bookmark = SessionBookmark(
+            sessionId: sessionId,
+            messageIndex: messageIndex,
+            label: label,
+            createdAt: Date()
+        )
+        projectBookmarks.append(bookmark)
+        all[key] = projectBookmarks
+        saveAll(all)
+        return bookmark
+    }
+
+    /// Removes a bookmark matching sessionId + messageIndex.
+    func removeBookmark(projectPath: String, sessionId: String, messageIndex: Int) {
+        var all = loadAll()
+        let key = projectPath.claudeProjectDirName
+        guard var projectBookmarks = all[key] else { return }
+
+        projectBookmarks.removeAll { $0.sessionId == sessionId && $0.messageIndex == messageIndex }
+        all[key] = projectBookmarks
+        saveAll(all)
+    }
+
+    /// Checks if a specific point is bookmarked.
+    func isBookmarked(projectPath: String, sessionId: String, messageIndex: Int) -> Bool {
+        let bookmarks = bookmarks(forProjectPath: projectPath)
+        return bookmarks.contains { $0.sessionId == sessionId && $0.messageIndex == messageIndex }
+    }
+
+    /// Returns the bookmark label for a specific point, or nil.
+    func bookmarkLabel(projectPath: String, sessionId: String, messageIndex: Int) -> String? {
+        let bookmarks = bookmarks(forProjectPath: projectPath)
+        return bookmarks.first(where: { $0.sessionId == sessionId && $0.messageIndex == messageIndex })?.label
+    }
+
+    // MARK: - Private
+
+    private func loadAll() -> [String: [SessionBookmark]] {
+        if let cached = cache { return cached }
+        guard let data = try? Data(contentsOf: fileURL),
+              let dict = try? JSONDecoder().decode([String: [SessionBookmark]].self, from: data) else {
+            cache = [:]
+            return [:]
+        }
+        cache = dict
+        return dict
+    }
+
+    private func saveAll(_ dict: [String: [SessionBookmark]]) {
+        cache = dict
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        guard let data = try? encoder.encode(dict) else { return }
+        try? data.write(to: fileURL, options: .atomic)
+    }
+}

--- a/Sources/Session/BookmarkManager.swift
+++ b/Sources/Session/BookmarkManager.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Manages session bookmarks persisted to ~/Library/Application Support/Deckard/session-bookmarks.json.
-/// Bookmarks are keyed by the encoded project path (matching Claude Code's convention).
+/// Stores a set of bookmarked session IDs per project path.
 class BookmarkManager {
     static let shared = BookmarkManager()
 
@@ -12,65 +12,46 @@ class BookmarkManager {
         return deckardDir.appendingPathComponent("session-bookmarks.json")
     }()
 
-    private var cache: [String: [SessionBookmark]]?
+    private var cache: [String: [String]]?  // projectKey -> [sessionId]
 
-    /// Returns all bookmarks for a given project path.
-    func bookmarks(forProjectPath projectPath: String) -> [SessionBookmark] {
+    /// Returns all bookmarked session IDs for a project.
+    func bookmarkedSessionIds(forProjectPath projectPath: String) -> Set<String> {
         let all = loadAll()
         let key = projectPath.claudeProjectDirName
-        return all[key] ?? []
+        return Set(all[key] ?? [])
     }
 
-    /// Adds a bookmark. Returns the created bookmark.
+    /// Checks if a session is bookmarked.
+    func isBookmarked(projectPath: String, sessionId: String) -> Bool {
+        bookmarkedSessionIds(forProjectPath: projectPath).contains(sessionId)
+    }
+
+    /// Toggles the bookmark state for a session. Returns the new state.
     @discardableResult
-    func addBookmark(projectPath: String, sessionId: String, messageIndex: Int, label: String) -> SessionBookmark {
+    func toggleBookmark(projectPath: String, sessionId: String) -> Bool {
         var all = loadAll()
         let key = projectPath.claudeProjectDirName
-        var projectBookmarks = all[key] ?? []
+        var ids = all[key] ?? []
 
-        let bookmark = SessionBookmark(
-            sessionId: sessionId,
-            messageIndex: messageIndex,
-            label: label,
-            createdAt: Date()
-        )
-        projectBookmarks.append(bookmark)
-        all[key] = projectBookmarks
-        saveAll(all)
-        return bookmark
-    }
-
-    /// Removes a bookmark matching sessionId + messageIndex.
-    func removeBookmark(projectPath: String, sessionId: String, messageIndex: Int) {
-        var all = loadAll()
-        let key = projectPath.claudeProjectDirName
-        guard var projectBookmarks = all[key] else { return }
-
-        projectBookmarks.removeAll { $0.sessionId == sessionId && $0.messageIndex == messageIndex }
-        all[key] = projectBookmarks
-        saveAll(all)
-    }
-
-    /// Checks if a specific point is bookmarked.
-    func isBookmarked(projectPath: String, sessionId: String, messageIndex: Int) -> Bool {
-        let bookmarks = bookmarks(forProjectPath: projectPath)
-        return bookmarks.contains { $0.sessionId == sessionId && $0.messageIndex == messageIndex }
-    }
-
-    /// Returns the bookmark label for a specific point, or nil.
-    func bookmarkLabel(projectPath: String, sessionId: String, messageIndex: Int) -> String? {
-        let bookmarks = bookmarks(forProjectPath: projectPath)
-        return bookmarks.first(where: { $0.sessionId == sessionId && $0.messageIndex == messageIndex })?.label
+        if let idx = ids.firstIndex(of: sessionId) {
+            ids.remove(at: idx)
+            all[key] = ids
+            saveAll(all)
+            return false
+        } else {
+            ids.append(sessionId)
+            all[key] = ids
+            saveAll(all)
+            return true
+        }
     }
 
     // MARK: - Private
 
-    private func loadAll() -> [String: [SessionBookmark]] {
+    private func loadAll() -> [String: [String]] {
         if let cached = cache { return cached }
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
         guard let data = try? Data(contentsOf: fileURL),
-              let dict = try? decoder.decode([String: [SessionBookmark]].self, from: data) else {
+              let dict = try? JSONDecoder().decode([String: [String]].self, from: data) else {
             cache = [:]
             return [:]
         }
@@ -78,11 +59,10 @@ class BookmarkManager {
         return dict
     }
 
-    private func saveAll(_ dict: [String: [SessionBookmark]]) {
+    private func saveAll(_ dict: [String: [String]]) {
         cache = dict
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        encoder.dateEncodingStrategy = .iso8601
         guard let data = try? encoder.encode(dict) else { return }
         try? data.write(to: fileURL, options: .atomic)
     }

--- a/Sources/Session/BookmarkManager.swift
+++ b/Sources/Session/BookmarkManager.swift
@@ -67,8 +67,10 @@ class BookmarkManager {
 
     private func loadAll() -> [String: [SessionBookmark]] {
         if let cached = cache { return cached }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
         guard let data = try? Data(contentsOf: fileURL),
-              let dict = try? JSONDecoder().decode([String: [SessionBookmark]].self, from: data) else {
+              let dict = try? decoder.decode([String: [SessionBookmark]].self, from: data) else {
             cache = [:]
             return [:]
         }

--- a/Sources/Session/SessionExplorerModels.swift
+++ b/Sources/Session/SessionExplorerModels.swift
@@ -18,6 +18,7 @@ struct TimelineEntry {
     let timestamp: Date?
     var isBookmarked: Bool
     var bookmarkLabel: String?
+    var actionSummary: String?
 }
 
 /// A starred point in a conversation, persisted to disk.

--- a/Sources/Session/SessionExplorerModels.swift
+++ b/Sources/Session/SessionExplorerModels.swift
@@ -5,7 +5,7 @@ struct ExplorerSessionInfo {
     let sessionId: String
     let filePath: URL
     let modificationDate: Date
-    let messageCount: Int
+    var messageCount: Int
     let firstUserMessage: String
     var summary: String?
 }

--- a/Sources/Session/SessionExplorerModels.swift
+++ b/Sources/Session/SessionExplorerModels.swift
@@ -7,6 +7,7 @@ struct ExplorerSessionInfo {
     let modificationDate: Date
     var messageCount: Int
     let firstUserMessage: String
+    var savedName: String?
     var summary: String?
 }
 

--- a/Sources/Session/SessionExplorerModels.swift
+++ b/Sources/Session/SessionExplorerModels.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// A Claude Code session on disk, enriched with parsed metadata.
+struct ExplorerSessionInfo {
+    let sessionId: String
+    let filePath: URL
+    let modificationDate: Date
+    let messageCount: Int
+    let firstUserMessage: String
+    var summary: String?
+}
+
+/// A single user turn within a session timeline.
+struct TimelineEntry {
+    let index: Int
+    let promptId: String
+    let message: String
+    let timestamp: Date?
+    var isBookmarked: Bool
+    var bookmarkLabel: String?
+}
+
+/// A starred point in a conversation, persisted to disk.
+struct SessionBookmark: Codable {
+    let sessionId: String
+    let messageIndex: Int
+    let label: String
+    let createdAt: Date
+}

--- a/Sources/Session/SessionExplorerModels.swift
+++ b/Sources/Session/SessionExplorerModels.swift
@@ -9,6 +9,7 @@ struct ExplorerSessionInfo {
     let firstUserMessage: String
     var savedName: String?
     var summary: String?
+    var isBookmarked: Bool
 }
 
 /// A single user turn within a session timeline.
@@ -17,15 +18,5 @@ struct TimelineEntry {
     let promptId: String
     let message: String
     let timestamp: Date?
-    var isBookmarked: Bool
-    var bookmarkLabel: String?
     var actionSummary: String?
-}
-
-/// A starred point in a conversation, persisted to disk.
-struct SessionBookmark: Codable {
-    let sessionId: String
-    let messageIndex: Int
-    let label: String
-    let createdAt: Date
 }

--- a/Sources/Session/SessionExplorerTimelineView.swift
+++ b/Sources/Session/SessionExplorerTimelineView.swift
@@ -247,6 +247,10 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         msgField.font = .systemFont(ofSize: 12)
         msgField.textColor = .labelColor
         msgField.lineBreakMode = .byTruncatingTail
+        msgField.maximumNumberOfLines = 5
+        msgField.cell?.wraps = true
+        msgField.cell?.isScrollable = false
+        msgField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         msgField.toolTip = entry.message
         msgField.translatesAutoresizingMaskIntoConstraints = false
         cell.addSubview(msgField)

--- a/Sources/Session/SessionExplorerTimelineView.swift
+++ b/Sources/Session/SessionExplorerTimelineView.swift
@@ -89,6 +89,13 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         }
     }
 
+    func updateActionSummaries(_ summaries: [Int: String]) {
+        for i in 0..<entries.count {
+            entries[i].actionSummary = summaries[entries[i].index]
+        }
+        tableView.reloadData()
+    }
+
     func reloadBookmarkState(projectPath: String, sessionId: String) {
         for i in 0..<entries.count {
             entries[i].isBookmarked = BookmarkManager.shared.isBookmarked(
@@ -198,7 +205,8 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
     }
 
     func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
-        60
+        guard row < entries.count else { return 60 }
+        return entries[row].actionSummary != nil ? 76 : 60
     }
 
     // MARK: - Timeline Cell
@@ -237,7 +245,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         msgField.translatesAutoresizingMaskIntoConstraints = false
         cell.addSubview(msgField)
 
-        // Timestamp + actions
+        // Timestamp
         var metaParts: [String] = []
         if let ts = entry.timestamp {
             metaParts.append(timeFormatter.string(from: ts))
@@ -249,11 +257,26 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         metaField.translatesAutoresizingMaskIntoConstraints = false
         cell.addSubview(metaField)
 
+        // Action summary (what Claude did in response)
+        let actionField: NSTextField?
+        if let summary = entry.actionSummary {
+            let field = NSTextField(labelWithString: "\u{2192} \(summary)")
+            field.font = .systemFont(ofSize: 11)
+            field.textColor = .secondaryLabelColor
+            field.lineBreakMode = .byTruncatingTail
+            field.translatesAutoresizingMaskIntoConstraints = false
+            cell.addSubview(field)
+            actionField = field
+        } else {
+            actionField = nil
+        }
+
         // Fork here button
-        let forkBtn = NSButton(title: "Fork here", target: nil, action: nil)
+        let forkBtn = NSButton(title: "", target: nil, action: nil)
+        forkBtn.image = NSImage(systemSymbolName: "arrow.branch", accessibilityDescription: "Fork here")
         forkBtn.bezelStyle = .inline
-        forkBtn.font = .systemFont(ofSize: 11)
         forkBtn.isBordered = false
+        forkBtn.toolTip = "Fork here"
         forkBtn.contentTintColor = NSColor(red: 0.4, green: 0.6, blue: 0.9, alpha: 0.8)
         forkBtn.tag = entry.index
         forkBtn.target = self
@@ -303,9 +326,17 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
 
             // Star
             starBtn.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -16),
-            starBtn.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+            starBtn.topAnchor.constraint(equalTo: cell.topAnchor, constant: 12),
             starBtn.widthAnchor.constraint(equalToConstant: 24),
         ])
+
+        if let actionField {
+            NSLayoutConstraint.activate([
+                actionField.leadingAnchor.constraint(equalTo: msgField.leadingAnchor),
+                actionField.trailingAnchor.constraint(equalTo: starBtn.leadingAnchor, constant: -8),
+                actionField.topAnchor.constraint(equalTo: metaField.bottomAnchor, constant: 1),
+            ])
+        }
 
         return cell
     }

--- a/Sources/Session/SessionExplorerTimelineView.swift
+++ b/Sources/Session/SessionExplorerTimelineView.swift
@@ -18,6 +18,12 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
     var onFork: ((String) -> Void)?
     var onForkAtPoint: ((String, Int) -> Void)?
     var onBookmarkToggle: ((String, TimelineEntry) -> Void)?
+    var onSummarizeSession: (() -> Void)?
+    var onSummarizeActions: (() -> Void)?
+
+    // Summarize buttons
+    private var summarizeSessionBtn: NSButton?
+    private var summarizeActionsBtn: NSButton?
 
     private let relativeFormatter: RelativeDateTimeFormatter = {
         let f = RelativeDateTimeFormatter()
@@ -56,14 +62,27 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
 
     // MARK: - Public
 
-    func showTimeline(session: ExplorerSessionInfo, entries: [TimelineEntry], scrollToIndex: Int?) {
+    func showTimeline(
+        session: ExplorerSessionInfo,
+        entries: [TimelineEntry],
+        cachedActionSummaries: [Int: String],
+        showSummarizeButton: Bool,
+        showSummarizeActionsButton: Bool,
+        scrollToIndex: Int?
+    ) {
         self.currentSession = session
         self.entries = entries
+        self.generatingTurnIndices.removeAll()
+
+        // Apply cached action summaries
+        for i in 0..<self.entries.count {
+            self.entries[i].actionSummary = cachedActionSummaries[self.entries[i].index]
+        }
 
         containerView.subviews.forEach { $0.removeFromSuperview() }
 
         // Header
-        let header = makeHeader(session: session)
+        let header = makeHeader(session: session, showSummarizeButton: showSummarizeButton, showSummarizeActionsButton: showSummarizeActionsButton)
         self.headerView = header
         header.translatesAutoresizingMaskIntoConstraints = false
         containerView.addSubview(header)
@@ -94,6 +113,14 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
     /// Updates the header title with a new summary.
     func updateHeaderSummary(_ summary: String) {
         headerTitleField?.stringValue = summary
+    }
+
+    func hideSummarizeSessionButton() {
+        summarizeSessionBtn?.isHidden = true
+    }
+
+    func hideSummarizeActionsButton() {
+        summarizeActionsBtn?.isHidden = true
     }
 
     /// Marks turns as currently generating (shows spinner on each row).
@@ -129,12 +156,12 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
 
     // MARK: - Header
 
-    private func makeHeader(session: ExplorerSessionInfo) -> NSView {
+    private func makeHeader(session: ExplorerSessionInfo, showSummarizeButton: Bool, showSummarizeActionsButton: Bool) -> NSView {
         let header = NSView()
         header.wantsLayer = true
         header.layer?.backgroundColor = NSColor(white: 0, alpha: 0.1).cgColor
 
-        let title = NSTextField(labelWithString: session.summary ?? session.firstUserMessage)
+        let title = NSTextField(labelWithString: session.summary ?? session.savedName ?? session.firstUserMessage)
         title.font = .systemFont(ofSize: 15, weight: .semibold)
         title.textColor = .labelColor
         title.lineBreakMode = .byTruncatingTail
@@ -151,6 +178,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         subtitle.textColor = .secondaryLabelColor
         subtitle.translatesAutoresizingMaskIntoConstraints = false
 
+        // Action buttons
         let resumeBtn = NSButton(title: "Resume", target: self, action: #selector(resumeClicked))
         resumeBtn.bezelStyle = .rounded
         resumeBtn.translatesAutoresizingMaskIntoConstraints = false
@@ -159,7 +187,30 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         forkBtn.bezelStyle = .rounded
         forkBtn.translatesAutoresizingMaskIntoConstraints = false
 
-        let buttonStack = NSStackView(views: [resumeBtn, forkBtn])
+        var actionButtons: [NSView] = [resumeBtn, forkBtn]
+
+        // Summarize buttons (only shown when there's something new to summarize)
+        if showSummarizeButton {
+            let btn = NSButton(title: "Summarize", target: self, action: #selector(summarizeSessionClicked))
+            btn.bezelStyle = .rounded
+            btn.translatesAutoresizingMaskIntoConstraints = false
+            self.summarizeSessionBtn = btn
+            actionButtons.append(btn)
+        } else {
+            self.summarizeSessionBtn = nil
+        }
+
+        if showSummarizeActionsButton {
+            let btn = NSButton(title: "Summarize Actions", target: self, action: #selector(summarizeActionsClicked))
+            btn.bezelStyle = .rounded
+            btn.translatesAutoresizingMaskIntoConstraints = false
+            self.summarizeActionsBtn = btn
+            actionButtons.append(btn)
+        } else {
+            self.summarizeActionsBtn = nil
+        }
+
+        let buttonStack = NSStackView(views: actionButtons)
         buttonStack.orientation = .horizontal
         buttonStack.spacing = 8
         buttonStack.translatesAutoresizingMaskIntoConstraints = false
@@ -177,7 +228,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
             subtitle.leadingAnchor.constraint(equalTo: title.leadingAnchor),
             subtitle.bottomAnchor.constraint(equalTo: header.bottomAnchor, constant: -12),
 
-            buttonStack.centerYAnchor.constraint(equalTo: header.centerYAnchor),
+            buttonStack.topAnchor.constraint(equalTo: header.topAnchor, constant: 12),
             buttonStack.trailingAnchor.constraint(equalTo: header.trailingAnchor, constant: -16),
         ])
 
@@ -192,6 +243,14 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
     @objc private func forkClicked() {
         guard let session = currentSession else { return }
         onFork?(session.sessionId)
+    }
+
+    @objc private func summarizeSessionClicked() {
+        onSummarizeSession?()
+    }
+
+    @objc private func summarizeActionsClicked() {
+        onSummarizeActions?()
     }
 
     // MARK: - Empty State

--- a/Sources/Session/SessionExplorerTimelineView.swift
+++ b/Sources/Session/SessionExplorerTimelineView.swift
@@ -65,7 +65,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         session: ExplorerSessionInfo,
         entries: [TimelineEntry],
         cachedActionSummaries: [Int: String],
-        showSummarizeButton: Bool,
+        summarizeEnabled: Bool,
         scrollToIndex: Int?
     ) {
         self.currentSession = session
@@ -79,7 +79,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         containerView.subviews.forEach { $0.removeFromSuperview() }
 
         // Header
-        let header = makeHeader(session: session, showSummarizeButton: showSummarizeButton)
+        let header = makeHeader(session: session, summarizeEnabled: summarizeEnabled)
         self.headerView = header
         header.translatesAutoresizingMaskIntoConstraints = false
         containerView.addSubview(header)
@@ -111,6 +111,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
     func updateHeaderSummary(_ summary: String) {
         if let existing = headerSummaryField {
             existing.stringValue = summary
+            headerView?.layoutSubtreeIfNeeded()
             return
         }
 
@@ -128,24 +129,19 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         header.addSubview(field)
         headerSummaryField = field
 
-        // Find the subtitle (second text field after title)
+        // Find the subtitle field
         let subtitleField = header.subviews.compactMap { $0 as? NSTextField }.first(where: { $0 !== titleField && $0 !== field })
 
+        // Replace bottom constraint — summary is now the bottom element
+        headerSummaryBottomConstraint?.isActive = false
         NSLayoutConstraint.activate([
             field.leadingAnchor.constraint(equalTo: titleField.leadingAnchor),
             field.trailingAnchor.constraint(equalTo: header.trailingAnchor, constant: -16),
             field.topAnchor.constraint(equalTo: (subtitleField ?? titleField).bottomAnchor, constant: 4),
         ])
-
-        // Update bottom constraint
-        headerSummaryBottomConstraint?.isActive = false
-        if let btn = summarizeBtn, !btn.isHidden {
-            // Button still visible — it goes below summary
-            headerSummaryBottomConstraint = btn.bottomAnchor.constraint(equalTo: header.bottomAnchor, constant: -12)
-        } else {
-            headerSummaryBottomConstraint = field.bottomAnchor.constraint(equalTo: header.bottomAnchor, constant: -12)
-        }
+        headerSummaryBottomConstraint = field.bottomAnchor.constraint(equalTo: header.bottomAnchor, constant: -12)
         headerSummaryBottomConstraint?.isActive = true
+        header.layoutSubtreeIfNeeded()
     }
 
     /// Transitions the button to a "generating" state: disabled, label changes, spinner appears.
@@ -167,7 +163,8 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
             ])
             summarizeSpinner = spinner
         } else {
-            btn.isHidden = true
+            btn.title = "Summarize with Haiku"
+            btn.isEnabled = false
             summarizeSpinner?.removeFromSuperview()
             summarizeSpinner = nil
         }
@@ -199,7 +196,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
 
     // MARK: - Header
 
-    private func makeHeader(session: ExplorerSessionInfo, showSummarizeButton: Bool) -> NSView {
+    private func makeHeader(session: ExplorerSessionInfo, summarizeEnabled: Bool) -> NSView {
         let header = NSView()
         header.wantsLayer = true
         header.layer?.backgroundColor = NSColor(white: 0, alpha: 0.1).cgColor
@@ -278,24 +275,20 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
             bottomAnchorView = field
         }
 
-        // Summarize button
-        if showSummarizeButton {
-            let btn = NSButton(title: "Summarize with Haiku", target: self, action: #selector(summarizeClicked))
-            btn.bezelStyle = .rounded
-            btn.controlSize = .small
-            btn.translatesAutoresizingMaskIntoConstraints = false
-            self.summarizeBtn = btn
-            header.addSubview(btn)
+        // Summarize button — always present, disabled when nothing to summarize
+        let btn = NSButton(title: "Summarize with Haiku", target: self, action: #selector(summarizeClicked))
+        btn.bezelStyle = .rounded
+        btn.controlSize = .small
+        btn.isEnabled = summarizeEnabled
+        btn.translatesAutoresizingMaskIntoConstraints = false
+        self.summarizeBtn = btn
+        header.addSubview(btn)
 
-            NSLayoutConstraint.activate([
-                btn.topAnchor.constraint(equalTo: bottomAnchorView.bottomAnchor, constant: 8),
-                btn.leadingAnchor.constraint(equalTo: title.leadingAnchor),
-            ])
-            headerSummaryBottomConstraint = btn.bottomAnchor.constraint(equalTo: header.bottomAnchor, constant: -12)
-        } else {
-            self.summarizeBtn = nil
-            headerSummaryBottomConstraint = bottomAnchorView.bottomAnchor.constraint(equalTo: header.bottomAnchor, constant: -12)
-        }
+        NSLayoutConstraint.activate([
+            btn.topAnchor.constraint(equalTo: bottomAnchorView.bottomAnchor, constant: 8),
+            btn.leadingAnchor.constraint(equalTo: title.leadingAnchor),
+        ])
+        headerSummaryBottomConstraint = btn.bottomAnchor.constraint(equalTo: header.bottomAnchor, constant: -12)
 
         headerSummaryBottomConstraint?.isActive = true
 

--- a/Sources/Session/SessionExplorerTimelineView.swift
+++ b/Sources/Session/SessionExplorerTimelineView.swift
@@ -10,7 +10,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
 
     private var currentSession: ExplorerSessionInfo?
     private var entries: [TimelineEntry] = []
-    private var generatingTurnIndex: Int? // which turn is currently being summarized
+    private var generatingTurnIndices = Set<Int>() // turns currently being summarized
 
     // Callbacks
     var onResume: ((String) -> Void)?
@@ -90,16 +90,17 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         }
     }
 
-    /// Marks a specific turn as currently generating (shows spinner on that row).
-    func setGeneratingTurn(_ turnIndex: Int?) {
-        generatingTurnIndex = turnIndex
+    /// Marks turns as currently generating (shows spinner on each row).
+    func setGeneratingTurns(_ turnIndices: Set<Int>) {
+        generatingTurnIndices = turnIndices
         tableView.reloadData()
     }
 
-    /// Updates a single turn's action summary and refreshes the table.
-    func updateActionSummary(turnIndex: Int, summary: String?) {
-        if let i = entries.firstIndex(where: { $0.index == turnIndex }) {
-            entries[i].actionSummary = summary
+    /// Updates all action summaries at once and clears generating state.
+    func updateActionSummaries(_ summaries: [Int: String]) {
+        generatingTurnIndices.removeAll()
+        for i in 0..<entries.count {
+            entries[i].actionSummary = summaries[entries[i].index]
         }
         tableView.reloadData()
     }
@@ -215,7 +216,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
     func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
         guard row < entries.count else { return 60 }
         let entry = entries[row]
-        let hasExtra = entry.actionSummary != nil || generatingTurnIndex == entry.index
+        let hasExtra = entry.actionSummary != nil || generatingTurnIndices.contains(entry.index)
         return hasExtra ? 76 : 60
     }
 
@@ -279,7 +280,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
             cell.addSubview(field)
             actionField = field
             actionSpinner = nil
-        } else if generatingTurnIndex == entry.index {
+        } else if generatingTurnIndices.contains(entry.index) {
             let spinner = NSProgressIndicator()
             spinner.style = .spinning
             spinner.controlSize = .small

--- a/Sources/Session/SessionExplorerTimelineView.swift
+++ b/Sources/Session/SessionExplorerTimelineView.swift
@@ -111,7 +111,8 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
     func updateHeaderSummary(_ summary: String) {
         if let existing = headerSummaryField {
             existing.stringValue = summary
-            headerView?.layoutSubtreeIfNeeded()
+            containerView.needsLayout = true
+            containerView.layoutSubtreeIfNeeded()
             return
         }
 
@@ -141,7 +142,8 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         ])
         headerSummaryBottomConstraint = field.bottomAnchor.constraint(equalTo: header.bottomAnchor, constant: -12)
         headerSummaryBottomConstraint?.isActive = true
-        header.layoutSubtreeIfNeeded()
+        containerView.needsLayout = true
+        containerView.layoutSubtreeIfNeeded()
     }
 
     /// Transitions the button to a "generating" state: disabled, label changes, spinner appears.

--- a/Sources/Session/SessionExplorerTimelineView.swift
+++ b/Sources/Session/SessionExplorerTimelineView.swift
@@ -5,9 +5,6 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
 
     private let containerView: NSView
     private var headerView: NSView?
-    private var headerTitleField: NSTextField?
-    private var headerSummaryField: NSTextField?
-    private var headerSummaryBottomConstraint: NSLayoutConstraint?
     private let scrollView = NSScrollView()
     private let tableView = NSTableView()
 
@@ -107,52 +104,13 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         }
     }
 
-    /// Adds or updates the AI summary below the subtitle in the header.
-    func updateHeaderSummary(_ summary: String) {
-        if let existing = headerSummaryField {
-            existing.stringValue = summary
-            containerView.needsLayout = true
-            containerView.layoutSubtreeIfNeeded()
-            return
-        }
-
-        guard let header = headerView, let titleField = headerTitleField else { return }
-
-        let field = NSTextField(labelWithString: summary)
-        field.font = .systemFont(ofSize: 12)
-        field.textColor = .secondaryLabelColor
-        field.lineBreakMode = .byTruncatingTail
-        field.maximumNumberOfLines = 5
-        field.cell?.wraps = true
-        field.cell?.isScrollable = false
-        field.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        field.translatesAutoresizingMaskIntoConstraints = false
-        header.addSubview(field)
-        headerSummaryField = field
-
-        // Find the subtitle field
-        let subtitleField = header.subviews.compactMap { $0 as? NSTextField }.first(where: { $0 !== titleField && $0 !== field })
-
-        // Replace bottom constraint — summary is now the bottom element
-        headerSummaryBottomConstraint?.isActive = false
-        NSLayoutConstraint.activate([
-            field.leadingAnchor.constraint(equalTo: titleField.leadingAnchor),
-            field.trailingAnchor.constraint(equalTo: header.trailingAnchor, constant: -16),
-            field.topAnchor.constraint(equalTo: (subtitleField ?? titleField).bottomAnchor, constant: 4),
-        ])
-        headerSummaryBottomConstraint = field.bottomAnchor.constraint(equalTo: header.bottomAnchor, constant: -12)
-        headerSummaryBottomConstraint?.isActive = true
-        containerView.needsLayout = true
-        containerView.layoutSubtreeIfNeeded()
-    }
-
     /// Transitions the button to a "generating" state: disabled, label changes, spinner appears.
     func setSummarizing(_ active: Bool) {
         guard let btn = summarizeBtn else { return }
-        if active {
-            btn.title = "Summarizing..."
-            btn.isEnabled = false
+        btn.title = active ? "Summarizing..." : "Summarize with Haiku"
+        btn.isEnabled = !active
 
+        if active {
             let spinner = NSProgressIndicator()
             spinner.style = .spinning
             spinner.controlSize = .small
@@ -165,17 +123,8 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
             ])
             summarizeSpinner = spinner
         } else {
-            btn.title = "Summarize with Haiku"
-            btn.isEnabled = false
             summarizeSpinner?.removeFromSuperview()
             summarizeSpinner = nil
-        }
-    }
-
-    /// Updates all action summaries at once.
-    func updateActionSummaries(_ summaries: [Int: String]) {
-        for i in 0..<entries.count {
-            entries[i].actionSummary = summaries[entries[i].index]
         }
         tableView.reloadData()
     }
@@ -213,8 +162,6 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         title.cell?.isScrollable = false
         title.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         title.translatesAutoresizingMaskIntoConstraints = false
-        self.headerTitleField = title
-        self.headerSummaryField = nil
 
         let timeStr = RelativeDateTimeFormatter().localizedString(for: session.modificationDate, relativeTo: Date())
         let subtitle = NSTextField(labelWithString: "\(session.messageCount) messages \u{00B7} \(timeStr)")
@@ -267,7 +214,6 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
             field.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
             field.translatesAutoresizingMaskIntoConstraints = false
             header.addSubview(field)
-            headerSummaryField = field
 
             NSLayoutConstraint.activate([
                 field.leadingAnchor.constraint(equalTo: title.leadingAnchor),
@@ -290,9 +236,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
             btn.topAnchor.constraint(equalTo: bottomAnchorView.bottomAnchor, constant: 8),
             btn.leadingAnchor.constraint(equalTo: title.leadingAnchor),
         ])
-        headerSummaryBottomConstraint = btn.bottomAnchor.constraint(equalTo: header.bottomAnchor, constant: -12)
-
-        headerSummaryBottomConstraint?.isActive = true
+        btn.bottomAnchor.constraint(equalTo: header.bottomAnchor, constant: -12).isActive = true
 
         return header
     }

--- a/Sources/Session/SessionExplorerTimelineView.swift
+++ b/Sources/Session/SessionExplorerTimelineView.swift
@@ -62,6 +62,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         entries: [TimelineEntry],
         cachedActionSummaries: [Int: String],
         summarizeEnabled: Bool,
+        resumeEnabled: Bool,
         scrollToIndex: Int?
     ) {
         self.currentSession = session
@@ -75,7 +76,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         containerView.subviews.forEach { $0.removeFromSuperview() }
 
         // Header
-        let header = makeHeader(session: session, summarizeEnabled: summarizeEnabled)
+        let header = makeHeader(session: session, summarizeEnabled: summarizeEnabled, resumeEnabled: resumeEnabled)
         self.headerView = header
         header.translatesAutoresizingMaskIntoConstraints = false
         containerView.addSubview(header)
@@ -130,7 +131,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
 
     // MARK: - Header
 
-    private func makeHeader(session: ExplorerSessionInfo, summarizeEnabled: Bool) -> NSView {
+    private func makeHeader(session: ExplorerSessionInfo, summarizeEnabled: Bool, resumeEnabled: Bool) -> NSView {
         let header = NSView()
         header.wantsLayer = true
         header.layer?.backgroundColor = NSColor(white: 0, alpha: 0.1).cgColor
@@ -155,6 +156,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         // Action buttons (top right)
         let resumeBtn = NSButton(title: "Resume", target: self, action: #selector(resumeClicked))
         resumeBtn.bezelStyle = .rounded
+        resumeBtn.isEnabled = resumeEnabled
         resumeBtn.translatesAutoresizingMaskIntoConstraints = false
 
         let forkBtn = NSButton(title: "Fork", target: self, action: #selector(forkClicked))

--- a/Sources/Session/SessionExplorerTimelineView.swift
+++ b/Sources/Session/SessionExplorerTimelineView.swift
@@ -55,28 +55,28 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         scrollView.drawsBackground = false
     }
 
+    struct TimelineOptions {
+        let cachedActionSummaries: [Int: String]
+        let summarizeEnabled: Bool
+        let resumeEnabled: Bool
+        let scrollToIndex: Int?
+    }
+
     // MARK: - Public
 
-    func showTimeline(
-        session: ExplorerSessionInfo,
-        entries: [TimelineEntry],
-        cachedActionSummaries: [Int: String],
-        summarizeEnabled: Bool,
-        resumeEnabled: Bool,
-        scrollToIndex: Int?
-    ) {
+    func showTimeline(session: ExplorerSessionInfo, entries: [TimelineEntry], options: TimelineOptions) {
         self.currentSession = session
         self.entries = entries
 
         // Apply cached action summaries
         for i in 0..<self.entries.count {
-            self.entries[i].actionSummary = cachedActionSummaries[self.entries[i].index]
+            self.entries[i].actionSummary = options.cachedActionSummaries[self.entries[i].index]
         }
 
         containerView.subviews.forEach { $0.removeFromSuperview() }
 
         // Header
-        let header = makeHeader(session: session, summarizeEnabled: summarizeEnabled, resumeEnabled: resumeEnabled)
+        let header = makeHeader(session: session, summarizeEnabled: options.summarizeEnabled, resumeEnabled: options.resumeEnabled)
         self.headerView = header
         header.translatesAutoresizingMaskIntoConstraints = false
         containerView.addSubview(header)
@@ -98,7 +98,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
 
         tableView.reloadData()
 
-        if let idx = scrollToIndex, idx < entries.count {
+        if let idx = options.scrollToIndex, idx < entries.count {
             tableView.scrollRowToVisible(idx)
             tableView.selectRowIndexes(IndexSet(integer: idx), byExtendingSelection: false)
         }

--- a/Sources/Session/SessionExplorerTimelineView.swift
+++ b/Sources/Session/SessionExplorerTimelineView.swift
@@ -5,6 +5,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
 
     private let containerView: NSView
     private var headerView: NSView?
+    private var headerTitleField: NSTextField?
     private let scrollView = NSScrollView()
     private let tableView = NSTableView()
 
@@ -90,6 +91,11 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         }
     }
 
+    /// Updates the header title with a new summary.
+    func updateHeaderSummary(_ summary: String) {
+        headerTitleField?.stringValue = summary
+    }
+
     /// Marks turns as currently generating (shows spinner on each row).
     func setGeneratingTurns(_ turnIndices: Set<Int>) {
         generatingTurnIndices = turnIndices
@@ -132,7 +138,12 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         title.font = .systemFont(ofSize: 15, weight: .semibold)
         title.textColor = .labelColor
         title.lineBreakMode = .byTruncatingTail
+        title.maximumNumberOfLines = 5
+        title.cell?.wraps = true
+        title.cell?.isScrollable = false
+        title.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         title.translatesAutoresizingMaskIntoConstraints = false
+        self.headerTitleField = title
 
         let timeStr = RelativeDateTimeFormatter().localizedString(for: session.modificationDate, relativeTo: Date())
         let subtitle = NSTextField(labelWithString: "\(session.messageCount) messages \u{00B7} \(timeStr)")

--- a/Sources/Session/SessionExplorerTimelineView.swift
+++ b/Sources/Session/SessionExplorerTimelineView.swift
@@ -44,7 +44,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         tableView.headerView = nil
         tableView.dataSource = self
         tableView.delegate = self
-        tableView.rowHeight = 60
+        tableView.usesAutomaticRowHeights = true
         tableView.backgroundColor = .clear
         tableView.selectionHighlightStyle = .none
 
@@ -213,12 +213,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         return makeTimelineCell(entry: entry, isLast: row == entries.count - 1)
     }
 
-    func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
-        guard row < entries.count else { return 60 }
-        let entry = entries[row]
-        let hasExtra = entry.actionSummary != nil || generatingTurnIndices.contains(entry.index)
-        return hasExtra ? 76 : 60
-    }
+    // Row heights are driven by usesAutomaticRowHeights + auto layout constraints
 
     // MARK: - Timeline Cell
 
@@ -276,6 +271,10 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
             field.font = .systemFont(ofSize: 11)
             field.textColor = .secondaryLabelColor
             field.lineBreakMode = .byTruncatingTail
+            field.maximumNumberOfLines = 5
+            field.cell?.wraps = true
+            field.cell?.isScrollable = false
+            field.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
             field.translatesAutoresizingMaskIntoConstraints = false
             cell.addSubview(field)
             actionField = field
@@ -294,15 +293,20 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
             actionSpinner = nil
         }
 
-        // Fork here button
+        // Fork here button (icon rotated 180° so arrows point down)
         let forkBtn = NSButton(title: "", target: nil, action: nil)
         if let branchImage = NSImage(systemSymbolName: "arrow.branch", accessibilityDescription: "Fork here") {
-            let flipped = NSImage(size: branchImage.size, flipped: true) { rect in
-                branchImage.draw(in: rect)
+            let size = branchImage.size
+            let rotated = NSImage(size: size, flipped: false) { _ in
+                let ctx = NSGraphicsContext.current!.cgContext
+                ctx.translateBy(x: size.width / 2, y: size.height / 2)
+                ctx.rotate(by: .pi)
+                ctx.translateBy(x: -size.width / 2, y: -size.height / 2)
+                branchImage.draw(in: NSRect(origin: .zero, size: size))
                 return true
             }
-            flipped.isTemplate = true
-            forkBtn.image = flipped
+            rotated.isTemplate = true
+            forkBtn.image = rotated
         }
         forkBtn.bezelStyle = .inline
         forkBtn.isBordered = false
@@ -365,6 +369,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
                 actionField.leadingAnchor.constraint(equalTo: msgField.leadingAnchor),
                 actionField.trailingAnchor.constraint(equalTo: starBtn.leadingAnchor, constant: -8),
                 actionField.topAnchor.constraint(equalTo: metaField.bottomAnchor, constant: 1),
+                actionField.bottomAnchor.constraint(equalTo: cell.bottomAnchor, constant: -8),
             ])
         } else if let actionSpinner {
             NSLayoutConstraint.activate([
@@ -372,7 +377,10 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
                 actionSpinner.topAnchor.constraint(equalTo: metaField.bottomAnchor, constant: 2),
                 actionSpinner.widthAnchor.constraint(equalToConstant: 14),
                 actionSpinner.heightAnchor.constraint(equalToConstant: 14),
+                actionSpinner.bottomAnchor.constraint(equalTo: cell.bottomAnchor, constant: -8),
             ])
+        } else {
+            metaField.bottomAnchor.constraint(equalTo: cell.bottomAnchor, constant: -8).isActive = true
         }
 
         return cell

--- a/Sources/Session/SessionExplorerTimelineView.swift
+++ b/Sources/Session/SessionExplorerTimelineView.swift
@@ -16,7 +16,6 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
     var onResume: ((String) -> Void)?
     var onFork: ((String) -> Void)?
     var onForkAtPoint: ((String, Int) -> Void)?
-    var onBookmarkToggle: ((String, TimelineEntry) -> Void)?
     var onSummarize: (() -> Void)?
 
     private var summarizeBtn: NSButton?
@@ -125,22 +124,6 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         } else {
             summarizeSpinner?.removeFromSuperview()
             summarizeSpinner = nil
-        }
-        tableView.reloadData()
-    }
-
-    func reloadBookmarkState(projectPath: String, sessionId: String) {
-        for i in 0..<entries.count {
-            entries[i].isBookmarked = BookmarkManager.shared.isBookmarked(
-                projectPath: projectPath,
-                sessionId: sessionId,
-                messageIndex: entries[i].index
-            )
-            entries[i].bookmarkLabel = BookmarkManager.shared.bookmarkLabel(
-                projectPath: projectPath,
-                sessionId: sessionId,
-                messageIndex: entries[i].index
-            )
         }
         tableView.reloadData()
     }
@@ -302,20 +285,14 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         // Dot
         let dot = NSView()
         dot.wantsLayer = true
-        let dotColor = entry.isBookmarked
-            ? NSColor(red: 1.0, green: 0.8, blue: 0.2, alpha: 0.7)
-            : NSColor(red: 0.4, green: 0.6, blue: 0.9, alpha: 0.7)
+        let dotColor = NSColor(red: 0.4, green: 0.6, blue: 0.9, alpha: 0.7)
         dot.layer?.backgroundColor = dotColor.cgColor
         dot.layer?.cornerRadius = 5
         dot.translatesAutoresizingMaskIntoConstraints = false
         cell.addSubview(dot)
 
         // Message text
-        var messageText = entry.message
-        if let label = entry.bookmarkLabel {
-            messageText += "  \u{2605} \(label)"
-        }
-        let msgField = NSTextField(labelWithString: messageText)
+        let msgField = NSTextField(labelWithString: entry.message)
         msgField.font = .systemFont(ofSize: 12)
         msgField.textColor = .labelColor
         msgField.lineBreakMode = .byTruncatingTail
@@ -382,20 +359,6 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         forkBtn.translatesAutoresizingMaskIntoConstraints = false
         cell.addSubview(forkBtn)
 
-        // Star toggle
-        let starBtn = NSButton(title: entry.isBookmarked ? "\u{2605}" : "\u{2606}", target: nil, action: nil)
-        starBtn.bezelStyle = .inline
-        starBtn.font = .systemFont(ofSize: 13)
-        starBtn.isBordered = false
-        starBtn.contentTintColor = entry.isBookmarked
-            ? NSColor(red: 1.0, green: 0.8, blue: 0.2, alpha: 0.7)
-            : NSColor.tertiaryLabelColor
-        starBtn.tag = entry.index
-        starBtn.target = self
-        starBtn.action = #selector(starClicked(_:))
-        starBtn.translatesAutoresizingMaskIntoConstraints = false
-        cell.addSubview(starBtn)
-
         NSLayoutConstraint.activate([
             // Vertical line
             line.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 24),
@@ -411,7 +374,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
 
             // Message
             msgField.leadingAnchor.constraint(equalTo: dot.trailingAnchor, constant: 12),
-            msgField.trailingAnchor.constraint(equalTo: starBtn.leadingAnchor, constant: -8),
+            msgField.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -16),
             msgField.topAnchor.constraint(equalTo: dot.topAnchor, constant: -2),
 
             // Meta
@@ -421,17 +384,12 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
             // Fork here
             forkBtn.leadingAnchor.constraint(equalTo: metaField.trailingAnchor, constant: 8),
             forkBtn.centerYAnchor.constraint(equalTo: metaField.centerYAnchor),
-
-            // Star
-            starBtn.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -16),
-            starBtn.topAnchor.constraint(equalTo: cell.topAnchor, constant: 12),
-            starBtn.widthAnchor.constraint(equalToConstant: 24),
         ])
 
         if let actionField {
             NSLayoutConstraint.activate([
                 actionField.leadingAnchor.constraint(equalTo: msgField.leadingAnchor),
-                actionField.trailingAnchor.constraint(equalTo: starBtn.leadingAnchor, constant: -8),
+                actionField.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -16),
                 actionField.topAnchor.constraint(equalTo: metaField.bottomAnchor, constant: 1),
                 actionField.bottomAnchor.constraint(equalTo: cell.bottomAnchor, constant: -8),
             ])
@@ -447,9 +405,4 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         onForkAtPoint?(session.sessionId, sender.tag)
     }
 
-    @objc private func starClicked(_ sender: NSButton) {
-        guard let session = currentSession, sender.tag < entries.count else { return }
-        let entry = entries[sender.tag]
-        onBookmarkToggle?(session.sessionId, entry)
-    }
 }

--- a/Sources/Session/SessionExplorerTimelineView.swift
+++ b/Sources/Session/SessionExplorerTimelineView.swift
@@ -18,12 +18,9 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
     var onFork: ((String) -> Void)?
     var onForkAtPoint: ((String, Int) -> Void)?
     var onBookmarkToggle: ((String, TimelineEntry) -> Void)?
-    var onSummarizeSession: (() -> Void)?
-    var onSummarizeActions: (() -> Void)?
+    var onSummarize: (() -> Void)?
 
-    // Summarize buttons
-    private var summarizeSessionBtn: NSButton?
-    private var summarizeActionsBtn: NSButton?
+    private var summarizeBtn: NSButton?
 
     private let relativeFormatter: RelativeDateTimeFormatter = {
         let f = RelativeDateTimeFormatter()
@@ -67,7 +64,6 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         entries: [TimelineEntry],
         cachedActionSummaries: [Int: String],
         showSummarizeButton: Bool,
-        showSummarizeActionsButton: Bool,
         scrollToIndex: Int?
     ) {
         self.currentSession = session
@@ -82,7 +78,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         containerView.subviews.forEach { $0.removeFromSuperview() }
 
         // Header
-        let header = makeHeader(session: session, showSummarizeButton: showSummarizeButton, showSummarizeActionsButton: showSummarizeActionsButton)
+        let header = makeHeader(session: session, showSummarizeButton: showSummarizeButton)
         self.headerView = header
         header.translatesAutoresizingMaskIntoConstraints = false
         containerView.addSubview(header)
@@ -115,12 +111,8 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         headerTitleField?.stringValue = summary
     }
 
-    func hideSummarizeSessionButton() {
-        summarizeSessionBtn?.isHidden = true
-    }
-
-    func hideSummarizeActionsButton() {
-        summarizeActionsBtn?.isHidden = true
+    func hideSummarizeButton() {
+        summarizeBtn?.isHidden = true
     }
 
     /// Marks turns as currently generating (shows spinner on each row).
@@ -156,7 +148,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
 
     // MARK: - Header
 
-    private func makeHeader(session: ExplorerSessionInfo, showSummarizeButton: Bool, showSummarizeActionsButton: Bool) -> NSView {
+    private func makeHeader(session: ExplorerSessionInfo, showSummarizeButton: Bool) -> NSView {
         let header = NSView()
         header.wantsLayer = true
         header.layer?.backgroundColor = NSColor(white: 0, alpha: 0.1).cgColor
@@ -178,7 +170,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         subtitle.textColor = .secondaryLabelColor
         subtitle.translatesAutoresizingMaskIntoConstraints = false
 
-        // Action buttons
+        // Action buttons (top right)
         let resumeBtn = NSButton(title: "Resume", target: self, action: #selector(resumeClicked))
         resumeBtn.bezelStyle = .rounded
         resumeBtn.translatesAutoresizingMaskIntoConstraints = false
@@ -187,30 +179,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         forkBtn.bezelStyle = .rounded
         forkBtn.translatesAutoresizingMaskIntoConstraints = false
 
-        var actionButtons: [NSView] = [resumeBtn, forkBtn]
-
-        // Summarize buttons (only shown when there's something new to summarize)
-        if showSummarizeButton {
-            let btn = NSButton(title: "Summarize", target: self, action: #selector(summarizeSessionClicked))
-            btn.bezelStyle = .rounded
-            btn.translatesAutoresizingMaskIntoConstraints = false
-            self.summarizeSessionBtn = btn
-            actionButtons.append(btn)
-        } else {
-            self.summarizeSessionBtn = nil
-        }
-
-        if showSummarizeActionsButton {
-            let btn = NSButton(title: "Summarize Actions", target: self, action: #selector(summarizeActionsClicked))
-            btn.bezelStyle = .rounded
-            btn.translatesAutoresizingMaskIntoConstraints = false
-            self.summarizeActionsBtn = btn
-            actionButtons.append(btn)
-        } else {
-            self.summarizeActionsBtn = nil
-        }
-
-        let buttonStack = NSStackView(views: actionButtons)
+        let buttonStack = NSStackView(views: [resumeBtn, forkBtn])
         buttonStack.orientation = .horizontal
         buttonStack.spacing = 8
         buttonStack.translatesAutoresizingMaskIntoConstraints = false
@@ -219,18 +188,48 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         header.addSubview(subtitle)
         header.addSubview(buttonStack)
 
-        NSLayoutConstraint.activate([
-            title.topAnchor.constraint(equalTo: header.topAnchor, constant: 12),
-            title.leadingAnchor.constraint(equalTo: header.leadingAnchor, constant: 16),
-            title.trailingAnchor.constraint(lessThanOrEqualTo: buttonStack.leadingAnchor, constant: -12),
+        // Summarize with AI button (bottom left, below subtitle)
+        if showSummarizeButton {
+            let btn = NSButton(title: "Summarize with AI", target: self, action: #selector(summarizeClicked))
+            btn.bezelStyle = .rounded
+            btn.controlSize = .small
+            btn.translatesAutoresizingMaskIntoConstraints = false
+            self.summarizeBtn = btn
+            header.addSubview(btn)
 
-            subtitle.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 2),
-            subtitle.leadingAnchor.constraint(equalTo: title.leadingAnchor),
-            subtitle.bottomAnchor.constraint(equalTo: header.bottomAnchor, constant: -12),
+            NSLayoutConstraint.activate([
+                btn.topAnchor.constraint(equalTo: subtitle.bottomAnchor, constant: 8),
+                btn.leadingAnchor.constraint(equalTo: title.leadingAnchor),
+                btn.bottomAnchor.constraint(equalTo: header.bottomAnchor, constant: -12),
+            ])
 
-            buttonStack.topAnchor.constraint(equalTo: header.topAnchor, constant: 12),
-            buttonStack.trailingAnchor.constraint(equalTo: header.trailingAnchor, constant: -16),
-        ])
+            NSLayoutConstraint.activate([
+                title.topAnchor.constraint(equalTo: header.topAnchor, constant: 12),
+                title.leadingAnchor.constraint(equalTo: header.leadingAnchor, constant: 16),
+                title.trailingAnchor.constraint(lessThanOrEqualTo: buttonStack.leadingAnchor, constant: -12),
+
+                subtitle.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 2),
+                subtitle.leadingAnchor.constraint(equalTo: title.leadingAnchor),
+
+                buttonStack.topAnchor.constraint(equalTo: header.topAnchor, constant: 12),
+                buttonStack.trailingAnchor.constraint(equalTo: header.trailingAnchor, constant: -16),
+            ])
+        } else {
+            self.summarizeBtn = nil
+
+            NSLayoutConstraint.activate([
+                title.topAnchor.constraint(equalTo: header.topAnchor, constant: 12),
+                title.leadingAnchor.constraint(equalTo: header.leadingAnchor, constant: 16),
+                title.trailingAnchor.constraint(lessThanOrEqualTo: buttonStack.leadingAnchor, constant: -12),
+
+                subtitle.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 2),
+                subtitle.leadingAnchor.constraint(equalTo: title.leadingAnchor),
+                subtitle.bottomAnchor.constraint(equalTo: header.bottomAnchor, constant: -12),
+
+                buttonStack.topAnchor.constraint(equalTo: header.topAnchor, constant: 12),
+                buttonStack.trailingAnchor.constraint(equalTo: header.trailingAnchor, constant: -16),
+            ])
+        }
 
         return header
     }
@@ -245,12 +244,8 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         onFork?(session.sessionId)
     }
 
-    @objc private func summarizeSessionClicked() {
-        onSummarizeSession?()
-    }
-
-    @objc private func summarizeActionsClicked() {
-        onSummarizeActions?()
+    @objc private func summarizeClicked() {
+        onSummarize?()
     }
 
     // MARK: - Empty State

--- a/Sources/Session/SessionExplorerTimelineView.swift
+++ b/Sources/Session/SessionExplorerTimelineView.swift
@@ -13,7 +13,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
 
     private var currentSession: ExplorerSessionInfo?
     private var entries: [TimelineEntry] = []
-    private var generatingTurnIndices = Set<Int>() // turns currently being summarized
+    private var summarizeSpinner: NSProgressIndicator?
 
     // Callbacks
     var onResume: ((String) -> Void)?
@@ -70,7 +70,6 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
     ) {
         self.currentSession = session
         self.entries = entries
-        self.generatingTurnIndices.removeAll()
 
         // Apply cached action summaries
         for i in 0..<self.entries.count {
@@ -149,19 +148,33 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         headerSummaryBottomConstraint?.isActive = true
     }
 
-    func hideSummarizeButton() {
-        summarizeBtn?.isHidden = true
+    /// Transitions the button to a "generating" state: disabled, label changes, spinner appears.
+    func setSummarizing(_ active: Bool) {
+        guard let btn = summarizeBtn else { return }
+        if active {
+            btn.title = "Summarizing..."
+            btn.isEnabled = false
+
+            let spinner = NSProgressIndicator()
+            spinner.style = .spinning
+            spinner.controlSize = .small
+            spinner.translatesAutoresizingMaskIntoConstraints = false
+            spinner.startAnimation(nil)
+            btn.superview?.addSubview(spinner)
+            NSLayoutConstraint.activate([
+                spinner.leadingAnchor.constraint(equalTo: btn.trailingAnchor, constant: 6),
+                spinner.centerYAnchor.constraint(equalTo: btn.centerYAnchor),
+            ])
+            summarizeSpinner = spinner
+        } else {
+            btn.isHidden = true
+            summarizeSpinner?.removeFromSuperview()
+            summarizeSpinner = nil
+        }
     }
 
-    /// Marks turns as currently generating (shows spinner on each row).
-    func setGeneratingTurns(_ turnIndices: Set<Int>) {
-        generatingTurnIndices = turnIndices
-        tableView.reloadData()
-    }
-
-    /// Updates all action summaries at once and clears generating state.
+    /// Updates all action summaries at once.
     func updateActionSummaries(_ summaries: [Int: String]) {
-        generatingTurnIndices.removeAll()
         for i in 0..<entries.count {
             entries[i].actionSummary = summaries[entries[i].index]
         }
@@ -387,9 +400,8 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         metaField.translatesAutoresizingMaskIntoConstraints = false
         cell.addSubview(metaField)
 
-        // Action summary (what Claude did in response) or spinner
+        // Action summary (what Claude did in response)
         let actionField: NSTextField?
-        let actionSpinner: NSProgressIndicator?
         if let summary = entry.actionSummary {
             let field = NSTextField(labelWithString: "\u{2192} \(summary)")
             field.font = .systemFont(ofSize: 11)
@@ -402,19 +414,8 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
             field.translatesAutoresizingMaskIntoConstraints = false
             cell.addSubview(field)
             actionField = field
-            actionSpinner = nil
-        } else if generatingTurnIndices.contains(entry.index) {
-            let spinner = NSProgressIndicator()
-            spinner.style = .spinning
-            spinner.controlSize = .small
-            spinner.translatesAutoresizingMaskIntoConstraints = false
-            spinner.startAnimation(nil)
-            cell.addSubview(spinner)
-            actionField = nil
-            actionSpinner = spinner
         } else {
             actionField = nil
-            actionSpinner = nil
         }
 
         // Fork here button (icon rotated 180° so arrows point down)
@@ -494,14 +495,6 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
                 actionField.trailingAnchor.constraint(equalTo: starBtn.leadingAnchor, constant: -8),
                 actionField.topAnchor.constraint(equalTo: metaField.bottomAnchor, constant: 1),
                 actionField.bottomAnchor.constraint(equalTo: cell.bottomAnchor, constant: -8),
-            ])
-        } else if let actionSpinner {
-            NSLayoutConstraint.activate([
-                actionSpinner.leadingAnchor.constraint(equalTo: msgField.leadingAnchor),
-                actionSpinner.topAnchor.constraint(equalTo: metaField.bottomAnchor, constant: 2),
-                actionSpinner.widthAnchor.constraint(equalToConstant: 14),
-                actionSpinner.heightAnchor.constraint(equalToConstant: 14),
-                actionSpinner.bottomAnchor.constraint(equalTo: cell.bottomAnchor, constant: -8),
             ])
         } else {
             metaField.bottomAnchor.constraint(equalTo: cell.bottomAnchor, constant: -8).isActive = true

--- a/Sources/Session/SessionExplorerTimelineView.swift
+++ b/Sources/Session/SessionExplorerTimelineView.swift
@@ -1,0 +1,323 @@
+import AppKit
+
+/// Manages the right pane of the session explorer: header with actions + timeline table.
+class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTableViewDelegate {
+
+    private let containerView: NSView
+    private var headerView: NSView?
+    private let scrollView = NSScrollView()
+    private let tableView = NSTableView()
+
+    private var currentSession: ExplorerSessionInfo?
+    private var entries: [TimelineEntry] = []
+
+    // Callbacks
+    var onResume: ((String) -> Void)?
+    var onFork: ((String) -> Void)?
+    var onForkAtPoint: ((String, Int) -> Void)?
+    var onBookmarkToggle: ((String, TimelineEntry) -> Void)?
+
+    private let relativeFormatter: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter()
+        f.unitsStyle = .abbreviated
+        return f
+    }()
+
+    private let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "h:mm a"
+        return f
+    }()
+
+    init(containerView: NSView) {
+        self.containerView = containerView
+        super.init()
+        setupTableView()
+        showEmptyState()
+    }
+
+    private func setupTableView() {
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("timeline"))
+        column.title = ""
+        tableView.addTableColumn(column)
+        tableView.headerView = nil
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.rowHeight = 60
+        tableView.backgroundColor = .clear
+        tableView.selectionHighlightStyle = .none
+
+        scrollView.documentView = tableView
+        scrollView.hasVerticalScroller = true
+        scrollView.drawsBackground = false
+    }
+
+    // MARK: - Public
+
+    func showTimeline(session: ExplorerSessionInfo, entries: [TimelineEntry], scrollToIndex: Int?) {
+        self.currentSession = session
+        self.entries = entries
+
+        containerView.subviews.forEach { $0.removeFromSuperview() }
+
+        // Header
+        let header = makeHeader(session: session)
+        self.headerView = header
+        header.translatesAutoresizingMaskIntoConstraints = false
+        containerView.addSubview(header)
+
+        // Timeline
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        containerView.addSubview(scrollView)
+
+        NSLayoutConstraint.activate([
+            header.topAnchor.constraint(equalTo: containerView.topAnchor),
+            header.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            header.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+
+            scrollView.topAnchor.constraint(equalTo: header.bottomAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+        ])
+
+        tableView.reloadData()
+
+        if let idx = scrollToIndex, idx < entries.count {
+            tableView.scrollRowToVisible(idx)
+            tableView.selectRowIndexes(IndexSet(integer: idx), byExtendingSelection: false)
+        }
+    }
+
+    func reloadBookmarkState(projectPath: String, sessionId: String) {
+        for i in 0..<entries.count {
+            entries[i].isBookmarked = BookmarkManager.shared.isBookmarked(
+                projectPath: projectPath,
+                sessionId: sessionId,
+                messageIndex: entries[i].index
+            )
+            entries[i].bookmarkLabel = BookmarkManager.shared.bookmarkLabel(
+                projectPath: projectPath,
+                sessionId: sessionId,
+                messageIndex: entries[i].index
+            )
+        }
+        tableView.reloadData()
+    }
+
+    // MARK: - Header
+
+    private func makeHeader(session: ExplorerSessionInfo) -> NSView {
+        let header = NSView()
+        header.wantsLayer = true
+        header.layer?.backgroundColor = NSColor(white: 0, alpha: 0.1).cgColor
+
+        let title = NSTextField(labelWithString: session.summary ?? session.firstUserMessage)
+        title.font = .systemFont(ofSize: 15, weight: .semibold)
+        title.textColor = .labelColor
+        title.lineBreakMode = .byTruncatingTail
+        title.translatesAutoresizingMaskIntoConstraints = false
+
+        let timeStr = RelativeDateTimeFormatter().localizedString(for: session.modificationDate, relativeTo: Date())
+        let subtitle = NSTextField(labelWithString: "\(session.messageCount) messages \u{00B7} \(timeStr)")
+        subtitle.font = .systemFont(ofSize: 12)
+        subtitle.textColor = .secondaryLabelColor
+        subtitle.translatesAutoresizingMaskIntoConstraints = false
+
+        let resumeBtn = NSButton(title: "Resume", target: self, action: #selector(resumeClicked))
+        resumeBtn.bezelStyle = .rounded
+        resumeBtn.translatesAutoresizingMaskIntoConstraints = false
+
+        let forkBtn = NSButton(title: "Fork", target: self, action: #selector(forkClicked))
+        forkBtn.bezelStyle = .rounded
+        forkBtn.translatesAutoresizingMaskIntoConstraints = false
+
+        let buttonStack = NSStackView(views: [resumeBtn, forkBtn])
+        buttonStack.orientation = .horizontal
+        buttonStack.spacing = 8
+        buttonStack.translatesAutoresizingMaskIntoConstraints = false
+
+        header.addSubview(title)
+        header.addSubview(subtitle)
+        header.addSubview(buttonStack)
+
+        NSLayoutConstraint.activate([
+            title.topAnchor.constraint(equalTo: header.topAnchor, constant: 12),
+            title.leadingAnchor.constraint(equalTo: header.leadingAnchor, constant: 16),
+            title.trailingAnchor.constraint(lessThanOrEqualTo: buttonStack.leadingAnchor, constant: -12),
+
+            subtitle.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 2),
+            subtitle.leadingAnchor.constraint(equalTo: title.leadingAnchor),
+            subtitle.bottomAnchor.constraint(equalTo: header.bottomAnchor, constant: -12),
+
+            buttonStack.centerYAnchor.constraint(equalTo: header.centerYAnchor),
+            buttonStack.trailingAnchor.constraint(equalTo: header.trailingAnchor, constant: -16),
+        ])
+
+        return header
+    }
+
+    @objc private func resumeClicked() {
+        guard let session = currentSession else { return }
+        onResume?(session.sessionId)
+    }
+
+    @objc private func forkClicked() {
+        guard let session = currentSession else { return }
+        onFork?(session.sessionId)
+    }
+
+    // MARK: - Empty State
+
+    private func showEmptyState() {
+        containerView.subviews.forEach { $0.removeFromSuperview() }
+
+        let label = NSTextField(labelWithString: "Select a session to view its timeline")
+        label.font = .systemFont(ofSize: 14)
+        label.textColor = .tertiaryLabelColor
+        label.alignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        containerView.addSubview(label)
+
+        NSLayoutConstraint.activate([
+            label.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
+        ])
+    }
+
+    // MARK: - NSTableViewDataSource & Delegate (timeline)
+
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        entries.count
+    }
+
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        guard row < entries.count else { return nil }
+        let entry = entries[row]
+        return makeTimelineCell(entry: entry, isLast: row == entries.count - 1)
+    }
+
+    func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
+        60
+    }
+
+    // MARK: - Timeline Cell
+
+    private func makeTimelineCell(entry: TimelineEntry, isLast: Bool) -> NSView {
+        let cell = NSView()
+
+        // Vertical line
+        let line = NSView()
+        line.wantsLayer = true
+        line.layer?.backgroundColor = NSColor.separatorColor.withAlphaComponent(0.3).cgColor
+        line.translatesAutoresizingMaskIntoConstraints = false
+        cell.addSubview(line)
+
+        // Dot
+        let dot = NSView()
+        dot.wantsLayer = true
+        let dotColor = entry.isBookmarked
+            ? NSColor(red: 1.0, green: 0.8, blue: 0.2, alpha: 0.7)
+            : NSColor(red: 0.4, green: 0.6, blue: 0.9, alpha: 0.7)
+        dot.layer?.backgroundColor = dotColor.cgColor
+        dot.layer?.cornerRadius = 5
+        dot.translatesAutoresizingMaskIntoConstraints = false
+        cell.addSubview(dot)
+
+        // Message text
+        var messageText = entry.message
+        if let label = entry.bookmarkLabel {
+            messageText += "  \u{2605} \(label)"
+        }
+        let msgField = NSTextField(labelWithString: messageText)
+        msgField.font = .systemFont(ofSize: 12)
+        msgField.textColor = .labelColor
+        msgField.lineBreakMode = .byTruncatingTail
+        msgField.toolTip = entry.message
+        msgField.translatesAutoresizingMaskIntoConstraints = false
+        cell.addSubview(msgField)
+
+        // Timestamp + actions
+        var metaParts: [String] = []
+        if let ts = entry.timestamp {
+            metaParts.append(timeFormatter.string(from: ts))
+        }
+
+        let metaField = NSTextField(labelWithString: metaParts.joined(separator: " \u{00B7} "))
+        metaField.font = .systemFont(ofSize: 11)
+        metaField.textColor = .tertiaryLabelColor
+        metaField.translatesAutoresizingMaskIntoConstraints = false
+        cell.addSubview(metaField)
+
+        // Fork here button
+        let forkBtn = NSButton(title: "Fork here", target: nil, action: nil)
+        forkBtn.bezelStyle = .inline
+        forkBtn.font = .systemFont(ofSize: 11)
+        forkBtn.isBordered = false
+        forkBtn.contentTintColor = NSColor(red: 0.4, green: 0.6, blue: 0.9, alpha: 0.8)
+        forkBtn.tag = entry.index
+        forkBtn.target = self
+        forkBtn.action = #selector(forkHereClicked(_:))
+        forkBtn.translatesAutoresizingMaskIntoConstraints = false
+        cell.addSubview(forkBtn)
+
+        // Star toggle
+        let starBtn = NSButton(title: entry.isBookmarked ? "\u{2605}" : "\u{2606}", target: nil, action: nil)
+        starBtn.bezelStyle = .inline
+        starBtn.font = .systemFont(ofSize: 13)
+        starBtn.isBordered = false
+        starBtn.contentTintColor = entry.isBookmarked
+            ? NSColor(red: 1.0, green: 0.8, blue: 0.2, alpha: 0.7)
+            : NSColor.tertiaryLabelColor
+        starBtn.tag = entry.index
+        starBtn.target = self
+        starBtn.action = #selector(starClicked(_:))
+        starBtn.translatesAutoresizingMaskIntoConstraints = false
+        cell.addSubview(starBtn)
+
+        NSLayoutConstraint.activate([
+            // Vertical line
+            line.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 24),
+            line.widthAnchor.constraint(equalToConstant: 2),
+            line.topAnchor.constraint(equalTo: cell.topAnchor),
+            line.bottomAnchor.constraint(equalTo: isLast ? dot.centerYAnchor : cell.bottomAnchor),
+
+            // Dot
+            dot.centerXAnchor.constraint(equalTo: line.centerXAnchor),
+            dot.topAnchor.constraint(equalTo: cell.topAnchor, constant: 12),
+            dot.widthAnchor.constraint(equalToConstant: 10),
+            dot.heightAnchor.constraint(equalToConstant: 10),
+
+            // Message
+            msgField.leadingAnchor.constraint(equalTo: dot.trailingAnchor, constant: 12),
+            msgField.trailingAnchor.constraint(equalTo: starBtn.leadingAnchor, constant: -8),
+            msgField.topAnchor.constraint(equalTo: dot.topAnchor, constant: -2),
+
+            // Meta
+            metaField.leadingAnchor.constraint(equalTo: msgField.leadingAnchor),
+            metaField.topAnchor.constraint(equalTo: msgField.bottomAnchor, constant: 2),
+
+            // Fork here
+            forkBtn.leadingAnchor.constraint(equalTo: metaField.trailingAnchor, constant: 8),
+            forkBtn.centerYAnchor.constraint(equalTo: metaField.centerYAnchor),
+
+            // Star
+            starBtn.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -16),
+            starBtn.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+            starBtn.widthAnchor.constraint(equalToConstant: 24),
+        ])
+
+        return cell
+    }
+
+    @objc private func forkHereClicked(_ sender: NSButton) {
+        guard let session = currentSession else { return }
+        onForkAtPoint?(session.sessionId, sender.tag)
+    }
+
+    @objc private func starClicked(_ sender: NSButton) {
+        guard let session = currentSession, sender.tag < entries.count else { return }
+        let entry = entries[sender.tag]
+        onBookmarkToggle?(session.sessionId, entry)
+    }
+}

--- a/Sources/Session/SessionExplorerTimelineView.swift
+++ b/Sources/Session/SessionExplorerTimelineView.swift
@@ -395,7 +395,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
 
         // Action summary (what Claude did in response)
         let actionField: NSTextField?
-        if let summary = entry.actionSummary {
+        if let summary = entry.actionSummary, !summary.isEmpty {
             let field = NSTextField(labelWithString: "\u{2192} \(summary)")
             field.font = .systemFont(ofSize: 11)
             field.textColor = .secondaryLabelColor

--- a/Sources/Session/SessionExplorerTimelineView.swift
+++ b/Sources/Session/SessionExplorerTimelineView.swift
@@ -10,7 +10,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
 
     private var currentSession: ExplorerSessionInfo?
     private var entries: [TimelineEntry] = []
-    private var actionSummarySpinner: NSProgressIndicator?
+    private var generatingTurnIndex: Int? // which turn is currently being summarized
 
     // Callbacks
     var onResume: ((String) -> Void)?
@@ -90,27 +90,16 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         }
     }
 
-    func showActionSummaryProgress() {
-        guard actionSummarySpinner == nil, let headerView else { return }
-        let spinner = NSProgressIndicator()
-        spinner.style = .spinning
-        spinner.controlSize = .small
-        spinner.translatesAutoresizingMaskIntoConstraints = false
-        spinner.startAnimation(nil)
-        headerView.addSubview(spinner)
-        NSLayoutConstraint.activate([
-            spinner.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: 16),
-            spinner.bottomAnchor.constraint(equalTo: headerView.bottomAnchor, constant: -8),
-        ])
-        actionSummarySpinner = spinner
+    /// Marks a specific turn as currently generating (shows spinner on that row).
+    func setGeneratingTurn(_ turnIndex: Int?) {
+        generatingTurnIndex = turnIndex
+        tableView.reloadData()
     }
 
-    func updateActionSummaries(_ summaries: [Int: String]) {
-        actionSummarySpinner?.stopAnimation(nil)
-        actionSummarySpinner?.removeFromSuperview()
-        actionSummarySpinner = nil
-        for i in 0..<entries.count {
-            entries[i].actionSummary = summaries[entries[i].index]
+    /// Updates a single turn's action summary and refreshes the table.
+    func updateActionSummary(turnIndex: Int, summary: String?) {
+        if let i = entries.firstIndex(where: { $0.index == turnIndex }) {
+            entries[i].actionSummary = summary
         }
         tableView.reloadData()
     }
@@ -225,7 +214,9 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
 
     func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
         guard row < entries.count else { return 60 }
-        return entries[row].actionSummary != nil ? 76 : 60
+        let entry = entries[row]
+        let hasExtra = entry.actionSummary != nil || generatingTurnIndex == entry.index
+        return hasExtra ? 76 : 60
     }
 
     // MARK: - Timeline Cell
@@ -276,8 +267,9 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         metaField.translatesAutoresizingMaskIntoConstraints = false
         cell.addSubview(metaField)
 
-        // Action summary (what Claude did in response)
+        // Action summary (what Claude did in response) or spinner
         let actionField: NSTextField?
+        let actionSpinner: NSProgressIndicator?
         if let summary = entry.actionSummary {
             let field = NSTextField(labelWithString: "\u{2192} \(summary)")
             field.font = .systemFont(ofSize: 11)
@@ -286,8 +278,19 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
             field.translatesAutoresizingMaskIntoConstraints = false
             cell.addSubview(field)
             actionField = field
+            actionSpinner = nil
+        } else if generatingTurnIndex == entry.index {
+            let spinner = NSProgressIndicator()
+            spinner.style = .spinning
+            spinner.controlSize = .small
+            spinner.translatesAutoresizingMaskIntoConstraints = false
+            spinner.startAnimation(nil)
+            cell.addSubview(spinner)
+            actionField = nil
+            actionSpinner = spinner
         } else {
             actionField = nil
+            actionSpinner = nil
         }
 
         // Fork here button
@@ -361,6 +364,13 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
                 actionField.leadingAnchor.constraint(equalTo: msgField.leadingAnchor),
                 actionField.trailingAnchor.constraint(equalTo: starBtn.leadingAnchor, constant: -8),
                 actionField.topAnchor.constraint(equalTo: metaField.bottomAnchor, constant: 1),
+            ])
+        } else if let actionSpinner {
+            NSLayoutConstraint.activate([
+                actionSpinner.leadingAnchor.constraint(equalTo: msgField.leadingAnchor),
+                actionSpinner.topAnchor.constraint(equalTo: metaField.bottomAnchor, constant: 2),
+                actionSpinner.widthAnchor.constraint(equalToConstant: 14),
+                actionSpinner.heightAnchor.constraint(equalToConstant: 14),
             ])
         }
 

--- a/Sources/Session/SessionExplorerTimelineView.swift
+++ b/Sources/Session/SessionExplorerTimelineView.swift
@@ -6,6 +6,8 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
     private let containerView: NSView
     private var headerView: NSView?
     private var headerTitleField: NSTextField?
+    private var headerSummaryField: NSTextField?
+    private var headerSummaryBottomConstraint: NSLayoutConstraint?
     private let scrollView = NSScrollView()
     private let tableView = NSTableView()
 
@@ -106,9 +108,45 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         }
     }
 
-    /// Updates the header title with a new summary.
+    /// Adds or updates the AI summary below the subtitle in the header.
     func updateHeaderSummary(_ summary: String) {
-        headerTitleField?.stringValue = summary
+        if let existing = headerSummaryField {
+            existing.stringValue = summary
+            return
+        }
+
+        guard let header = headerView, let titleField = headerTitleField else { return }
+
+        let field = NSTextField(labelWithString: summary)
+        field.font = .systemFont(ofSize: 12)
+        field.textColor = .secondaryLabelColor
+        field.lineBreakMode = .byTruncatingTail
+        field.maximumNumberOfLines = 5
+        field.cell?.wraps = true
+        field.cell?.isScrollable = false
+        field.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        field.translatesAutoresizingMaskIntoConstraints = false
+        header.addSubview(field)
+        headerSummaryField = field
+
+        // Find the subtitle (second text field after title)
+        let subtitleField = header.subviews.compactMap { $0 as? NSTextField }.first(where: { $0 !== titleField && $0 !== field })
+
+        NSLayoutConstraint.activate([
+            field.leadingAnchor.constraint(equalTo: titleField.leadingAnchor),
+            field.trailingAnchor.constraint(equalTo: header.trailingAnchor, constant: -16),
+            field.topAnchor.constraint(equalTo: (subtitleField ?? titleField).bottomAnchor, constant: 4),
+        ])
+
+        // Update bottom constraint
+        headerSummaryBottomConstraint?.isActive = false
+        if let btn = summarizeBtn, !btn.isHidden {
+            // Button still visible — it goes below summary
+            headerSummaryBottomConstraint = btn.bottomAnchor.constraint(equalTo: header.bottomAnchor, constant: -12)
+        } else {
+            headerSummaryBottomConstraint = field.bottomAnchor.constraint(equalTo: header.bottomAnchor, constant: -12)
+        }
+        headerSummaryBottomConstraint?.isActive = true
     }
 
     func hideSummarizeButton() {
@@ -153,7 +191,8 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         header.wantsLayer = true
         header.layer?.backgroundColor = NSColor(white: 0, alpha: 0.1).cgColor
 
-        let title = NSTextField(labelWithString: session.summary ?? session.savedName ?? session.firstUserMessage)
+        // Title: always the saved name or first user message
+        let title = NSTextField(labelWithString: session.savedName ?? session.firstUserMessage)
         title.font = .systemFont(ofSize: 15, weight: .semibold)
         title.textColor = .labelColor
         title.lineBreakMode = .byTruncatingTail
@@ -163,6 +202,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         title.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         title.translatesAutoresizingMaskIntoConstraints = false
         self.headerTitleField = title
+        self.headerSummaryField = nil
 
         let timeStr = RelativeDateTimeFormatter().localizedString(for: session.modificationDate, relativeTo: Date())
         let subtitle = NSTextField(labelWithString: "\(session.messageCount) messages \u{00B7} \(timeStr)")
@@ -188,9 +228,46 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         header.addSubview(subtitle)
         header.addSubview(buttonStack)
 
-        // Summarize with AI button (bottom left, below subtitle)
+        NSLayoutConstraint.activate([
+            title.topAnchor.constraint(equalTo: header.topAnchor, constant: 12),
+            title.leadingAnchor.constraint(equalTo: header.leadingAnchor, constant: 16),
+            title.trailingAnchor.constraint(lessThanOrEqualTo: buttonStack.leadingAnchor, constant: -12),
+
+            subtitle.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 2),
+            subtitle.leadingAnchor.constraint(equalTo: title.leadingAnchor),
+
+            buttonStack.topAnchor.constraint(equalTo: header.topAnchor, constant: 12),
+            buttonStack.trailingAnchor.constraint(equalTo: header.trailingAnchor, constant: -16),
+        ])
+
+        // Track what the current bottom element is
+        var bottomAnchorView: NSView = subtitle
+
+        // Show existing summary if cached
+        if let summary = session.summary {
+            let field = NSTextField(labelWithString: summary)
+            field.font = .systemFont(ofSize: 12)
+            field.textColor = .secondaryLabelColor
+            field.lineBreakMode = .byTruncatingTail
+            field.maximumNumberOfLines = 5
+            field.cell?.wraps = true
+            field.cell?.isScrollable = false
+            field.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+            field.translatesAutoresizingMaskIntoConstraints = false
+            header.addSubview(field)
+            headerSummaryField = field
+
+            NSLayoutConstraint.activate([
+                field.leadingAnchor.constraint(equalTo: title.leadingAnchor),
+                field.trailingAnchor.constraint(equalTo: header.trailingAnchor, constant: -16),
+                field.topAnchor.constraint(equalTo: subtitle.bottomAnchor, constant: 4),
+            ])
+            bottomAnchorView = field
+        }
+
+        // Summarize button
         if showSummarizeButton {
-            let btn = NSButton(title: "Summarize with AI", target: self, action: #selector(summarizeClicked))
+            let btn = NSButton(title: "Summarize with Haiku", target: self, action: #selector(summarizeClicked))
             btn.bezelStyle = .rounded
             btn.controlSize = .small
             btn.translatesAutoresizingMaskIntoConstraints = false
@@ -198,38 +275,16 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
             header.addSubview(btn)
 
             NSLayoutConstraint.activate([
-                btn.topAnchor.constraint(equalTo: subtitle.bottomAnchor, constant: 8),
+                btn.topAnchor.constraint(equalTo: bottomAnchorView.bottomAnchor, constant: 8),
                 btn.leadingAnchor.constraint(equalTo: title.leadingAnchor),
-                btn.bottomAnchor.constraint(equalTo: header.bottomAnchor, constant: -12),
             ])
-
-            NSLayoutConstraint.activate([
-                title.topAnchor.constraint(equalTo: header.topAnchor, constant: 12),
-                title.leadingAnchor.constraint(equalTo: header.leadingAnchor, constant: 16),
-                title.trailingAnchor.constraint(lessThanOrEqualTo: buttonStack.leadingAnchor, constant: -12),
-
-                subtitle.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 2),
-                subtitle.leadingAnchor.constraint(equalTo: title.leadingAnchor),
-
-                buttonStack.topAnchor.constraint(equalTo: header.topAnchor, constant: 12),
-                buttonStack.trailingAnchor.constraint(equalTo: header.trailingAnchor, constant: -16),
-            ])
+            headerSummaryBottomConstraint = btn.bottomAnchor.constraint(equalTo: header.bottomAnchor, constant: -12)
         } else {
             self.summarizeBtn = nil
-
-            NSLayoutConstraint.activate([
-                title.topAnchor.constraint(equalTo: header.topAnchor, constant: 12),
-                title.leadingAnchor.constraint(equalTo: header.leadingAnchor, constant: 16),
-                title.trailingAnchor.constraint(lessThanOrEqualTo: buttonStack.leadingAnchor, constant: -12),
-
-                subtitle.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 2),
-                subtitle.leadingAnchor.constraint(equalTo: title.leadingAnchor),
-                subtitle.bottomAnchor.constraint(equalTo: header.bottomAnchor, constant: -12),
-
-                buttonStack.topAnchor.constraint(equalTo: header.topAnchor, constant: 12),
-                buttonStack.trailingAnchor.constraint(equalTo: header.trailingAnchor, constant: -16),
-            ])
+            headerSummaryBottomConstraint = bottomAnchorView.bottomAnchor.constraint(equalTo: header.bottomAnchor, constant: -12)
         }
+
+        headerSummaryBottomConstraint?.isActive = true
 
         return header
     }

--- a/Sources/Session/SessionExplorerTimelineView.swift
+++ b/Sources/Session/SessionExplorerTimelineView.swift
@@ -10,6 +10,7 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
 
     private var currentSession: ExplorerSessionInfo?
     private var entries: [TimelineEntry] = []
+    private var actionSummarySpinner: NSProgressIndicator?
 
     // Callbacks
     var onResume: ((String) -> Void)?
@@ -89,7 +90,25 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
         }
     }
 
+    func showActionSummaryProgress() {
+        guard actionSummarySpinner == nil, let headerView else { return }
+        let spinner = NSProgressIndicator()
+        spinner.style = .spinning
+        spinner.controlSize = .small
+        spinner.translatesAutoresizingMaskIntoConstraints = false
+        spinner.startAnimation(nil)
+        headerView.addSubview(spinner)
+        NSLayoutConstraint.activate([
+            spinner.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: 16),
+            spinner.bottomAnchor.constraint(equalTo: headerView.bottomAnchor, constant: -8),
+        ])
+        actionSummarySpinner = spinner
+    }
+
     func updateActionSummaries(_ summaries: [Int: String]) {
+        actionSummarySpinner?.stopAnimation(nil)
+        actionSummarySpinner?.removeFromSuperview()
+        actionSummarySpinner = nil
         for i in 0..<entries.count {
             entries[i].actionSummary = summaries[entries[i].index]
         }
@@ -273,7 +292,14 @@ class SessionExplorerTimelineController: NSObject, NSTableViewDataSource, NSTabl
 
         // Fork here button
         let forkBtn = NSButton(title: "", target: nil, action: nil)
-        forkBtn.image = NSImage(systemSymbolName: "arrow.branch", accessibilityDescription: "Fork here")
+        if let branchImage = NSImage(systemSymbolName: "arrow.branch", accessibilityDescription: "Fork here") {
+            let flipped = NSImage(size: branchImage.size, flipped: true) { rect in
+                branchImage.draw(in: rect)
+                return true
+            }
+            flipped.isTemplate = true
+            forkBtn.image = flipped
+        }
         forkBtn.bezelStyle = .inline
         forkBtn.isBordered = false
         forkBtn.toolTip = "Fork here"

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -195,7 +195,22 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
                 $0.label.lowercased().contains(query)
             }
         }
+        // Preserve selection across reload
+        let previousSelection = selectedSessionId
         listTableView.reloadData()
+        if let prevId = previousSelection {
+            restoreListSelection(sessionId: prevId)
+        }
+    }
+
+    /// Restores the list selection to match the given sessionId.
+    private func restoreListSelection(sessionId: String) {
+        let bookmarkCount = filteredBookmarks.count
+        let hasDivider = bookmarkCount > 0
+        let offset = bookmarkCount + (hasDivider ? 1 : 0)
+        if let idx = filteredSessions.firstIndex(where: { $0.sessionId == sessionId }) {
+            listTableView.selectRowIndexes(IndexSet(integer: offset + idx), byExtendingSelection: false)
+        }
     }
 
     // MARK: - Actions

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -112,7 +112,7 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
         listTableView.headerView = nil
         listTableView.dataSource = self
         listTableView.delegate = self
-        listTableView.rowHeight = 52
+        listTableView.rowHeight = 64
         listTableView.backgroundColor = .clear
         listTableView.selectionHighlightStyle = .regular
         listTableView.target = self
@@ -409,7 +409,7 @@ extension SessionExplorerWindowController: NSTableViewDataSource, NSTableViewDel
         let bookmarkCount = filteredBookmarks.count
         let hasDivider = bookmarkCount > 0
         if hasDivider && row == bookmarkCount { return 16 }  // divider
-        return 52
+        return 64
     }
 
     func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool {
@@ -436,8 +436,13 @@ extension SessionExplorerWindowController: NSTableViewDataSource, NSTableViewDel
         let title = NSTextField(labelWithString: bookmark.label)
         title.font = .systemFont(ofSize: 13, weight: .semibold)
         title.textColor = .labelColor
-        title.lineBreakMode = .byTruncatingTail
+        title.lineBreakMode = .byWordWrapping
+        title.maximumNumberOfLines = 2
+        title.preferredMaxLayoutWidth = 200
+        title.cell?.wraps = true
+        title.cell?.isScrollable = false
         title.translatesAutoresizingMaskIntoConstraints = false
+        title.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
         let subtitle = NSTextField(labelWithString: "\(sessionSummary) \u{00B7} msg \(bookmark.messageIndex + 1)")
         subtitle.font = .systemFont(ofSize: 11)
@@ -485,8 +490,13 @@ extension SessionExplorerWindowController: NSTableViewDataSource, NSTableViewDel
         let title = NSTextField(labelWithString: session.summary ?? session.firstUserMessage)
         title.font = .systemFont(ofSize: 13, weight: session.sessionId == selectedSessionId ? .semibold : .regular)
         title.textColor = .labelColor
-        title.lineBreakMode = .byTruncatingTail
+        title.lineBreakMode = .byWordWrapping
+        title.maximumNumberOfLines = 2
+        title.preferredMaxLayoutWidth = 200
+        title.cell?.wraps = true
+        title.cell?.isScrollable = false
         title.translatesAutoresizingMaskIntoConstraints = false
+        title.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
         let timeStr = relativeFormatter.localizedString(for: session.modificationDate, relativeTo: Date())
         let subtitleText = session.messageCount > 0 ? "\(timeStr) \u{00B7} \(session.messageCount) msgs" : timeStr

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -357,6 +357,14 @@ extension SessionExplorerWindowController: NSTableViewDataSource, NSTableViewDel
         filteredSessions.count
     }
 
+    func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
+        guard row < filteredSessions.count, filteredSessions[row].isBookmarked else { return nil }
+        let rowView = NSTableRowView()
+        rowView.wantsLayer = true
+        rowView.layer?.backgroundColor = NSColor(red: 1.0, green: 0.85, blue: 0.2, alpha: 0.06).cgColor
+        return rowView
+    }
+
     func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
         guard row < filteredSessions.count else { return nil }
         return makeSessionCell(session: filteredSessions[row], row: row)
@@ -364,11 +372,6 @@ extension SessionExplorerWindowController: NSTableViewDataSource, NSTableViewDel
 
     private func makeSessionCell(session: ExplorerSessionInfo, row: Int) -> NSView {
         let cell = NSTableCellView()
-
-        if session.isBookmarked {
-            cell.wantsLayer = true
-            cell.layer?.backgroundColor = NSColor(red: 1.0, green: 0.85, blue: 0.2, alpha: 0.06).cgColor
-        }
 
         // Star toggle
         let starBtn = NSButton(title: session.isBookmarked ? "\u{2605}" : "\u{2606}", target: self, action: #selector(starClicked(_:)))

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -392,11 +392,10 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
                let idx = self.allSessions.firstIndex(where: { $0.sessionId == sessionId }) {
                 self.allSessions[idx].summary = summary
                 self.applyFilter()
-                self.timelineController?.updateHeaderSummary(summary)
             }
 
-            self.timelineController?.updateActionSummaries(actionSummaries)
-            self.timelineController?.setSummarizing(false)
+            // Rebuild the entire right pane with updated data
+            self.selectSession(sessionId: sessionId, scrollToMessageIndex: nil)
         }
     }
 

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -318,10 +318,12 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
         timelineController?.showTimeline(
             session: updatedSession,
             entries: entries,
-            cachedActionSummaries: cachedActionSummaries,
-            summarizeEnabled: summarizeEnabled,
-            resumeEnabled: !isOpen,
-            scrollToIndex: scrollToMessageIndex
+            options: .init(
+                cachedActionSummaries: cachedActionSummaries,
+                summarizeEnabled: summarizeEnabled,
+                resumeEnabled: !isOpen,
+                scrollToIndex: scrollToMessageIndex
+            )
         )
 
         timelineController?.onSummarize = { [weak self] in

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -392,7 +392,6 @@ extension SessionExplorerWindowController: NSTableViewDataSource, NSTableViewDel
         title.textColor = .labelColor
         title.lineBreakMode = .byTruncatingTail
         title.maximumNumberOfLines = 5
-        title.preferredMaxLayoutWidth = 200
         title.cell?.wraps = true
         title.cell?.isScrollable = false
         title.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -112,7 +112,7 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
         listTableView.headerView = nil
         listTableView.dataSource = self
         listTableView.delegate = self
-        listTableView.rowHeight = 64
+        listTableView.usesAutomaticRowHeights = true
         listTableView.backgroundColor = .clear
         listTableView.selectionHighlightStyle = .regular
         listTableView.target = self
@@ -360,6 +360,13 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
             entries: enrichedEntries,
             scrollToIndex: scrollToMessageIndex
         )
+
+        // Generate action summaries for each turn
+        let actions = ContextMonitor.shared.parseActions(sessionId: sessionId, projectPath: projectPath)
+        SummaryManager.shared.generateTurnSummaries(sessionId: sessionId, actions: actions) { [weak self] summaries in
+            guard let self, self.selectedSessionId == sessionId else { return }
+            self.timelineController?.updateActionSummaries(summaries)
+        }
     }
 
     // MARK: - NSSplitViewDelegate
@@ -465,6 +472,7 @@ extension SessionExplorerWindowController: NSTableViewDataSource, NSTableViewDel
             subtitle.leadingAnchor.constraint(equalTo: title.leadingAnchor),
             subtitle.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -8),
             subtitle.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 2),
+            subtitle.bottomAnchor.constraint(equalTo: cell.bottomAnchor, constant: -8),
         ])
 
         return cell
@@ -490,8 +498,8 @@ extension SessionExplorerWindowController: NSTableViewDataSource, NSTableViewDel
         let title = NSTextField(labelWithString: session.summary ?? session.firstUserMessage)
         title.font = .systemFont(ofSize: 13, weight: session.sessionId == selectedSessionId ? .semibold : .regular)
         title.textColor = .labelColor
-        title.lineBreakMode = .byWordWrapping
-        title.maximumNumberOfLines = 2
+        title.lineBreakMode = .byTruncatingTail
+        title.maximumNumberOfLines = 5
         title.preferredMaxLayoutWidth = 200
         title.cell?.wraps = true
         title.cell?.isScrollable = false
@@ -525,9 +533,10 @@ extension SessionExplorerWindowController: NSTableViewDataSource, NSTableViewDel
             subtitle.leadingAnchor.constraint(equalTo: title.leadingAnchor),
             subtitle.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -12),
             subtitle.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 2),
+            subtitle.bottomAnchor.constraint(equalTo: cell.bottomAnchor, constant: -8),
 
             spinner.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -12),
-            spinner.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+            spinner.topAnchor.constraint(equalTo: cell.topAnchor, constant: 8),
             spinner.widthAnchor.constraint(equalToConstant: 16),
             spinner.heightAnchor.constraint(equalToConstant: 16),
         ])

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -317,23 +317,28 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
         selectedSessionId = sessionId
         guard let session = allSessions.first(where: { $0.sessionId == sessionId }) else { return }
 
-        // Trigger summary generation if needed
-        if session.summary == nil {
-            SummaryManager.shared.generateSummary(sessionId: sessionId, projectPath: projectPath) { [weak self] summary in
+        let entries = ContextMonitor.shared.parseTimeline(sessionId: sessionId, projectPath: projectPath)
+        let turnCount = entries.count
+
+        // Update message count now that we've parsed the full file
+        if let idx = allSessions.firstIndex(where: { $0.sessionId == sessionId }) {
+            allSessions[idx].messageCount = turnCount
+        }
+
+        // Generate or regenerate session summary if session has new turns
+        let cachedTurnCount = SummaryManager.shared.cachedSummaryTurnCount(forSessionId: sessionId)
+        if cachedTurnCount < turnCount || session.summary == nil {
+            SummaryManager.shared.generateSummary(sessionId: sessionId, projectPath: projectPath, currentTurnCount: turnCount) { [weak self] summary in
                 guard let self else { return }
                 if let idx = self.allSessions.firstIndex(where: { $0.sessionId == sessionId }), let summary {
                     self.allSessions[idx].summary = summary
                     self.applyFilter()
+                    // Also update the timeline header
+                    if self.selectedSessionId == sessionId {
+                        self.timelineController?.updateHeaderSummary(summary)
+                    }
                 }
             }
-        }
-
-        let entries = ContextMonitor.shared.parseTimeline(sessionId: sessionId, projectPath: projectPath)
-
-        // Update message count now that we've parsed the full file
-        if let idx = allSessions.firstIndex(where: { $0.sessionId == sessionId }), allSessions[idx].messageCount == 0 {
-            allSessions[idx].messageCount = entries.count
-            applyFilter()
         }
 
         // Use the session with updated messageCount for the timeline header
@@ -502,7 +507,8 @@ extension SessionExplorerWindowController: NSTableViewDataSource, NSTableViewDel
     private func makeSessionCell(session: ExplorerSessionInfo) -> NSView {
         let cell = NSTableCellView()
 
-        let title = NSTextField(labelWithString: session.summary ?? session.firstUserMessage)
+        // First user message as title
+        let title = NSTextField(labelWithString: session.firstUserMessage)
         title.font = .systemFont(ofSize: 13, weight: session.sessionId == selectedSessionId ? .semibold : .regular)
         title.textColor = .labelColor
         title.lineBreakMode = .byTruncatingTail
@@ -513,12 +519,30 @@ extension SessionExplorerWindowController: NSTableViewDataSource, NSTableViewDel
         title.translatesAutoresizingMaskIntoConstraints = false
         title.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
+        // AI-generated summary below the title
+        let summaryField: NSTextField?
+        if let summary = session.summary {
+            let field = NSTextField(labelWithString: summary)
+            field.font = .systemFont(ofSize: 11)
+            field.textColor = .secondaryLabelColor
+            field.lineBreakMode = .byTruncatingTail
+            field.maximumNumberOfLines = 5
+            field.cell?.wraps = true
+            field.cell?.isScrollable = false
+            field.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+            field.translatesAutoresizingMaskIntoConstraints = false
+            summaryField = field
+        } else {
+            summaryField = nil
+        }
+
+        // Timestamp + message count
         let timeStr = relativeFormatter.localizedString(for: session.modificationDate, relativeTo: Date())
-        let subtitleText = session.messageCount > 0 ? "\(timeStr) \u{00B7} \(session.messageCount) msgs" : timeStr
-        let subtitle = NSTextField(labelWithString: subtitleText)
-        subtitle.font = .systemFont(ofSize: 11)
-        subtitle.textColor = .secondaryLabelColor
-        subtitle.translatesAutoresizingMaskIntoConstraints = false
+        let metaText = session.messageCount > 0 ? "\(timeStr) \u{00B7} \(session.messageCount) msgs" : timeStr
+        let metaField = NSTextField(labelWithString: metaText)
+        metaField.font = .systemFont(ofSize: 10)
+        metaField.textColor = .tertiaryLabelColor
+        metaField.translatesAutoresizingMaskIntoConstraints = false
 
         // Spinner for summary generation
         let spinner = NSProgressIndicator()
@@ -529,24 +553,37 @@ extension SessionExplorerWindowController: NSTableViewDataSource, NSTableViewDel
         if !spinner.isHidden { spinner.startAnimation(nil) }
 
         cell.addSubview(title)
-        cell.addSubview(subtitle)
+        cell.addSubview(metaField)
+        if let summaryField { cell.addSubview(summaryField) }
         cell.addSubview(spinner)
+
+        // Bottom anchor: summary if present, otherwise meta
+        let bottomView: NSView = summaryField ?? metaField
 
         NSLayoutConstraint.activate([
             title.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 12),
             title.trailingAnchor.constraint(equalTo: spinner.leadingAnchor, constant: -4),
             title.topAnchor.constraint(equalTo: cell.topAnchor, constant: 8),
 
-            subtitle.leadingAnchor.constraint(equalTo: title.leadingAnchor),
-            subtitle.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -12),
-            subtitle.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 2),
-            subtitle.bottomAnchor.constraint(equalTo: cell.bottomAnchor, constant: -8),
+            metaField.leadingAnchor.constraint(equalTo: title.leadingAnchor),
+            metaField.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -12),
+            metaField.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 2),
+
+            bottomView.bottomAnchor.constraint(equalTo: cell.bottomAnchor, constant: -8),
 
             spinner.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -12),
             spinner.topAnchor.constraint(equalTo: cell.topAnchor, constant: 8),
             spinner.widthAnchor.constraint(equalToConstant: 16),
             spinner.heightAnchor.constraint(equalToConstant: 16),
         ])
+
+        if let summaryField {
+            NSLayoutConstraint.activate([
+                summaryField.leadingAnchor.constraint(equalTo: title.leadingAnchor),
+                summaryField.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -12),
+                summaryField.topAnchor.constraint(equalTo: metaField.bottomAnchor, constant: 2),
+            ])
+        }
 
         return cell
     }

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -8,8 +8,8 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
     private let projectName: String
 
     /// Callback invoked when the user picks an action (resume/fork).
-    /// Parameters: sessionId, forkSession flag.
-    var onSessionAction: ((String, Bool) -> Void)?
+    /// Parameters: sessionId, forkSession flag, tab name.
+    var onSessionAction: ((String, Bool, String?) -> Void)?
 
     // --- Data ---
     private var allSessions: [ExplorerSessionInfo] = []
@@ -215,19 +215,28 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
 
     // MARK: - Actions
 
+    private func sessionDisplayName(for sessionId: String) -> String? {
+        guard let session = allSessions.first(where: { $0.sessionId == sessionId }) else { return nil }
+        // Prefer summary, fall back to first user message truncated
+        if let summary = session.summary { return summary }
+        let msg = session.firstUserMessage
+        return msg.isEmpty ? nil : String(msg.prefix(60))
+    }
+
     private func performAction(sessionId: String, fork: Bool) {
-        onSessionAction?(sessionId, fork)
+        onSessionAction?(sessionId, fork, sessionDisplayName(for: sessionId))
         close()
     }
 
     private func performForkAtPoint(sessionId: String, turnIndex: Int) {
+        let name = sessionDisplayName(for: sessionId)
         guard let newSessionId = ContextMonitor.shared.truncateSession(
             sessionId: sessionId,
             projectPath: projectPath,
             afterTurnIndex: turnIndex
         ) else { return }
 
-        onSessionAction?(newSessionId, true)
+        onSessionAction?(newSessionId, true, name)
         close()
     }
 

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -362,8 +362,7 @@ extension SessionExplorerWindowController: NSTableViewDataSource, NSTableViewDel
     func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
         guard row < filteredSessions.count, filteredSessions[row].isBookmarked else { return nil }
         let rowView = NSTableRowView()
-        rowView.wantsLayer = true
-        rowView.layer?.backgroundColor = NSColor(red: 1.0, green: 0.85, blue: 0.2, alpha: 0.06).cgColor
+        rowView.backgroundColor = NSColor(red: 1.0, green: 0.85, blue: 0.2, alpha: 0.06)
         return rowView
     }
 

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -216,9 +216,10 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
     // MARK: - Actions
 
     private func sessionDisplayName(for sessionId: String) -> String? {
+        // Prefer saved session name (from tab rename), then first user message
+        let savedNames = SessionManager.shared.loadSessionNames()
+        if let name = savedNames[sessionId], !name.isEmpty { return name }
         guard let session = allSessions.first(where: { $0.sessionId == sessionId }) else { return nil }
-        // Prefer summary, fall back to first user message truncated
-        if let summary = session.summary { return summary }
         let msg = session.firstUserMessage
         return msg.isEmpty ? nil : String(msg.prefix(60))
     }

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -362,13 +362,13 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
         }
         let cachedTurnCount = SummaryManager.shared.cachedSummaryTurnCount(forSessionId: sessionId)
         let needsSessionSummary = session.summary == nil || cachedTurnCount < entries.count
-        let needsSummarization = needsSessionSummary || hasUncachedActions
+        let summarizeEnabled = needsSessionSummary || hasUncachedActions
 
         timelineController?.showTimeline(
             session: updatedSession,
             entries: enrichedEntries,
             cachedActionSummaries: cachedActionSummaries,
-            showSummarizeButton: needsSummarization,
+            summarizeEnabled: summarizeEnabled,
             scrollToIndex: scrollToMessageIndex
         )
 

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -11,6 +11,9 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
     /// Parameters: sessionId, forkSession flag, tab name.
     var onSessionAction: ((String, Bool, String?) -> Void)?
 
+    /// Session IDs currently open in the project's tabs.
+    var openSessionIds = Set<String>()
+
     // --- Data ---
     private var allSessions: [ExplorerSessionInfo] = []
     private var filteredSessions: [ExplorerSessionInfo] = []
@@ -310,11 +313,14 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
         let needsSessionSummary = updatedSession.summary == nil || cachedTurnCount < entries.count
         let summarizeEnabled = needsSessionSummary || hasUncachedActions
 
+        let isOpen = openSessionIds.contains(sessionId)
+
         timelineController?.showTimeline(
             session: updatedSession,
             entries: entries,
             cachedActionSummaries: cachedActionSummaries,
             summarizeEnabled: summarizeEnabled,
+            resumeEnabled: !isOpen,
             scrollToIndex: scrollToMessageIndex
         )
 

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -361,27 +361,15 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
             scrollToIndex: scrollToMessageIndex
         )
 
-        // Generate action summaries one at a time, top to bottom
+        // Generate action summaries in one batch haiku call, with per-row spinners
         let actions = ContextMonitor.shared.parseActions(sessionId: sessionId, projectPath: projectPath)
-        let turnIndices = entries.map { $0.index }.filter { actions[$0] != nil && !actions[$0]!.isEmpty }
-        generateNextTurnSummary(sessionId: sessionId, turnIndices: turnIndices, actions: actions, position: 0)
-    }
-
-    private func generateNextTurnSummary(sessionId: String, turnIndices: [Int], actions: [Int: [String]], position: Int) {
-        guard position < turnIndices.count, selectedSessionId == sessionId else {
-            timelineController?.setGeneratingTurn(nil)
-            return
+        let turnIndices = Set(entries.map { $0.index }.filter { actions[$0] != nil && !actions[$0]!.isEmpty })
+        if !turnIndices.isEmpty {
+            timelineController?.setGeneratingTurns(turnIndices)
         }
-
-        let turnIndex = turnIndices[position]
-        let turnActions = actions[turnIndex] ?? []
-
-        timelineController?.setGeneratingTurn(turnIndex)
-
-        SummaryManager.shared.generateSingleTurnSummary(sessionId: sessionId, turnIndex: turnIndex, actions: turnActions) { [weak self] summary in
+        SummaryManager.shared.generateTurnSummaries(sessionId: sessionId, actions: actions) { [weak self] summaries in
             guard let self, self.selectedSessionId == sessionId else { return }
-            self.timelineController?.updateActionSummary(turnIndex: turnIndex, summary: summary)
-            self.generateNextTurnSummary(sessionId: sessionId, turnIndices: turnIndices, actions: actions, position: position + 1)
+            self.timelineController?.updateActionSummaries(summaries)
         }
     }
 

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -110,7 +110,9 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
 
         let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("session"))
         column.title = ""
+        column.resizingMask = .autoresizingMask
         listTableView.addTableColumn(column)
+        listTableView.columnAutoresizingStyle = .lastColumnOnlyAutoresizingStyle
         listTableView.headerView = nil
         listTableView.dataSource = self
         listTableView.delegate = self

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -326,27 +326,10 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
         guard let session = allSessions.first(where: { $0.sessionId == sessionId }) else { return }
 
         let entries = ContextMonitor.shared.parseTimeline(sessionId: sessionId, projectPath: projectPath)
-        let turnCount = entries.count
 
         // Update message count now that we've parsed the full file
         if let idx = allSessions.firstIndex(where: { $0.sessionId == sessionId }) {
-            allSessions[idx].messageCount = turnCount
-        }
-
-        // Generate or regenerate session summary if session has new turns
-        let cachedTurnCount = SummaryManager.shared.cachedSummaryTurnCount(forSessionId: sessionId)
-        if cachedTurnCount < turnCount || session.summary == nil {
-            SummaryManager.shared.generateSummary(sessionId: sessionId, projectPath: projectPath, currentTurnCount: turnCount) { [weak self] summary in
-                guard let self else { return }
-                if let idx = self.allSessions.firstIndex(where: { $0.sessionId == sessionId }), let summary {
-                    self.allSessions[idx].summary = summary
-                    self.applyFilter()
-                    // Also update the timeline header
-                    if self.selectedSessionId == sessionId {
-                        self.timelineController?.updateHeaderSummary(summary)
-                    }
-                }
-            }
+            allSessions[idx].messageCount = entries.count
         }
 
         // Use the session with updated messageCount for the timeline header
@@ -368,14 +351,55 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
             return e
         }
 
+        // Load cached action summaries (no AI call — just what we already have)
+        let cachedActionSummaries = SummaryManager.shared.cachedTurnSummaries(forSessionId: sessionId)
+
+        // Check if there are uncached turns that could be summarized
+        let actions = ContextMonitor.shared.parseActions(sessionId: sessionId, projectPath: projectPath)
+        let hasUncachedActions = entries.contains { entry in
+            let turnActions = actions[entry.index] ?? []
+            return !turnActions.isEmpty && cachedActionSummaries[entry.index] == nil
+        }
+
+        // Check if session summary needs (re)generation
+        let cachedTurnCount = SummaryManager.shared.cachedSummaryTurnCount(forSessionId: sessionId)
+        let needsSessionSummary = session.summary == nil || cachedTurnCount < entries.count
+
         timelineController?.showTimeline(
             session: updatedSession,
             entries: enrichedEntries,
+            cachedActionSummaries: cachedActionSummaries,
+            showSummarizeButton: needsSessionSummary,
+            showSummarizeActionsButton: hasUncachedActions,
             scrollToIndex: scrollToMessageIndex
         )
 
-        // Generate action summaries — cached turns load instantly, only new ones hit haiku
-        let actions = ContextMonitor.shared.parseActions(sessionId: sessionId, projectPath: projectPath)
+        timelineController?.onSummarizeSession = { [weak self] in
+            self?.summarizeSession(sessionId: sessionId)
+        }
+        timelineController?.onSummarizeActions = { [weak self] in
+            self?.summarizeActions(sessionId: sessionId, entries: entries, actions: actions)
+        }
+    }
+
+    private func summarizeSession(sessionId: String) {
+        guard let session = allSessions.first(where: { $0.sessionId == sessionId }) else { return }
+        let turnCount = session.messageCount
+
+        SummaryManager.shared.generateSummary(sessionId: sessionId, projectPath: projectPath, currentTurnCount: turnCount) { [weak self] summary in
+            guard let self else { return }
+            if let idx = self.allSessions.firstIndex(where: { $0.sessionId == sessionId }), let summary {
+                self.allSessions[idx].summary = summary
+                self.applyFilter()
+                if self.selectedSessionId == sessionId {
+                    self.timelineController?.updateHeaderSummary(summary)
+                    self.timelineController?.hideSummarizeSessionButton()
+                }
+            }
+        }
+    }
+
+    private func summarizeActions(sessionId: String, entries: [TimelineEntry], actions: [Int: [String]]) {
         let cached = SummaryManager.shared.cachedTurnSummaries(forSessionId: sessionId)
         let uncachedTurns = Set(entries.map { $0.index }.filter {
             actions[$0] != nil && !actions[$0]!.isEmpty && cached[$0] == nil
@@ -386,6 +410,7 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
         SummaryManager.shared.generateTurnSummaries(sessionId: sessionId, actions: actions) { [weak self] summaries in
             guard let self, self.selectedSessionId == sessionId else { return }
             self.timelineController?.updateActionSummaries(summaries)
+            self.timelineController?.hideSummarizeActionsButton()
         }
     }
 

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -307,7 +307,7 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
             return !turnActions.isEmpty && cachedActionSummaries[entry.index] == nil
         }
         let cachedTurnCount = SummaryManager.shared.cachedSummaryTurnCount(forSessionId: sessionId)
-        let needsSessionSummary = session.summary == nil || cachedTurnCount < entries.count
+        let needsSessionSummary = updatedSession.summary == nil || cachedTurnCount < entries.count
         let summarizeEnabled = needsSessionSummary || hasUncachedActions
 
         timelineController?.showTimeline(

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -343,10 +343,8 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
             if let summary = sessionSummary,
                let idx = self.allSessions.firstIndex(where: { $0.sessionId == sessionId }) {
                 self.allSessions[idx].summary = summary
-                // Update just this row in the left sidebar without resetting scroll
                 if let fIdx = self.filteredSessions.firstIndex(where: { $0.sessionId == sessionId }) {
                     self.filteredSessions[fIdx].summary = summary
-                    self.listTableView.reloadData(forRowIndexes: IndexSet(integer: fIdx), columnIndexes: IndexSet(integer: 0))
                 }
             }
 
@@ -406,19 +404,8 @@ extension SessionExplorerWindowController: NSTableViewDataSource, NSTableViewDel
         metaField.font = .systemFont(ofSize: 10)
         metaField.textColor = .tertiaryLabelColor
 
-        // Text stack (title + meta + optional summary)
-        var textViews: [NSView] = [title, metaField]
-
-        if let summary = session.summary {
-            let field = NSTextField(labelWithString: summary)
-            field.font = .systemFont(ofSize: 11)
-            field.textColor = .secondaryLabelColor
-            field.lineBreakMode = .byTruncatingTail
-            field.maximumNumberOfLines = 2
-            textViews.append(field)
-        }
-
-        let textStack = NSStackView(views: textViews)
+        // Text stack (title + meta)
+        let textStack = NSStackView(views: [title, metaField])
         textStack.orientation = .vertical
         textStack.alignment = .leading
         textStack.spacing = 2

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -262,8 +262,12 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
         }
         if let fIdx = filteredSessions.firstIndex(where: { $0.sessionId == sessionId }) {
             filteredSessions[fIdx].isBookmarked = newState
-            listTableView.reloadData(forRowIndexes: IndexSet(integer: fIdx), columnIndexes: IndexSet(integer: 0))
         }
+        // Update only the button itself — no row reload
+        sender.title = newState ? "\u{2605}" : "\u{2606}"
+        sender.contentTintColor = newState
+            ? NSColor(red: 1.0, green: 0.8, blue: 0.2, alpha: 0.7)
+            : NSColor.tertiaryLabelColor
     }
 
     // MARK: - Search
@@ -357,13 +361,6 @@ extension SessionExplorerWindowController: NSTableViewDataSource, NSTableViewDel
 
     func numberOfRows(in tableView: NSTableView) -> Int {
         filteredSessions.count
-    }
-
-    func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
-        guard row < filteredSessions.count, filteredSessions[row].isBookmarked else { return nil }
-        let rowView = NSTableRowView()
-        rowView.backgroundColor = NSColor(red: 1.0, green: 0.85, blue: 0.2, alpha: 0.06)
-        return rowView
     }
 
     func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -207,8 +207,11 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
 
         filteredSessions = sessions
 
+        // Preserve scroll position and selection across reload
+        let scrollPosition = listScrollView.contentView.bounds.origin
         let previousSelection = selectedSessionId
         listTableView.reloadData()
+        listScrollView.contentView.scroll(to: scrollPosition)
         if let prevId = previousSelection {
             restoreListSelection(sessionId: prevId)
         }

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -361,14 +361,27 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
             scrollToIndex: scrollToMessageIndex
         )
 
-        // Generate action summaries for each turn
+        // Generate action summaries one at a time, top to bottom
         let actions = ContextMonitor.shared.parseActions(sessionId: sessionId, projectPath: projectPath)
-        if !actions.isEmpty {
-            timelineController?.showActionSummaryProgress()
+        let turnIndices = entries.map { $0.index }.filter { actions[$0] != nil && !actions[$0]!.isEmpty }
+        generateNextTurnSummary(sessionId: sessionId, turnIndices: turnIndices, actions: actions, position: 0)
+    }
+
+    private func generateNextTurnSummary(sessionId: String, turnIndices: [Int], actions: [Int: [String]], position: Int) {
+        guard position < turnIndices.count, selectedSessionId == sessionId else {
+            timelineController?.setGeneratingTurn(nil)
+            return
         }
-        SummaryManager.shared.generateTurnSummaries(sessionId: sessionId, actions: actions) { [weak self] summaries in
+
+        let turnIndex = turnIndices[position]
+        let turnActions = actions[turnIndex] ?? []
+
+        timelineController?.setGeneratingTurn(turnIndex)
+
+        SummaryManager.shared.generateSingleTurnSummary(sessionId: sessionId, turnIndex: turnIndex, actions: turnActions) { [weak self] summary in
             guard let self, self.selectedSessionId == sessionId else { return }
-            self.timelineController?.updateActionSummaries(summaries)
+            self.timelineController?.updateActionSummary(turnIndex: turnIndex, summary: summary)
+            self.generateNextTurnSummary(sessionId: sessionId, turnIndices: turnIndices, actions: actions, position: position + 1)
         }
     }
 

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -361,11 +361,14 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
             scrollToIndex: scrollToMessageIndex
         )
 
-        // Generate action summaries in one batch haiku call, with per-row spinners
+        // Generate action summaries — cached turns load instantly, only new ones hit haiku
         let actions = ContextMonitor.shared.parseActions(sessionId: sessionId, projectPath: projectPath)
-        let turnIndices = Set(entries.map { $0.index }.filter { actions[$0] != nil && !actions[$0]!.isEmpty })
-        if !turnIndices.isEmpty {
-            timelineController?.setGeneratingTurns(turnIndices)
+        let cached = SummaryManager.shared.cachedTurnSummaries(forSessionId: sessionId)
+        let uncachedTurns = Set(entries.map { $0.index }.filter {
+            actions[$0] != nil && !actions[$0]!.isEmpty && cached[$0] == nil
+        })
+        if !uncachedTurns.isEmpty {
+            timelineController?.setGeneratingTurns(uncachedTurns)
         }
         SummaryManager.shared.generateTurnSummaries(sessionId: sessionId, actions: actions) { [weak self] summaries in
             guard let self, self.selectedSessionId == sessionId else { return }

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -245,6 +245,10 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
     }
 
     private func promptForBookmarkLabel(defaultLabel: String, completion: @escaping (String?) -> Void) {
+        guard let window else {
+            completion(nil)
+            return
+        }
         let alert = NSAlert()
         alert.messageText = "Bookmark Label"
         alert.informativeText = "Enter a name for this bookmark:"
@@ -255,7 +259,7 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
         input.stringValue = defaultLabel
         alert.accessoryView = input
 
-        alert.beginSheetModal(for: window!) { response in
+        alert.beginSheetModal(for: window) { response in
             if response == .alertFirstButtonReturn {
                 let label = input.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
                 completion(label.isEmpty ? defaultLabel : label)
@@ -500,6 +504,8 @@ extension SessionExplorerWindowController: NSTableViewDataSource, NSTableViewDel
 
 extension SessionExplorerWindowController: NSWindowDelegate {
     func windowWillClose(_ notification: Notification) {
-        // Allow deallocation
+        if let w = window {
+            objc_setAssociatedObject(w, "explorerController", nil, .OBJC_ASSOCIATION_RETAIN)
+        }
     }
 }

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -389,7 +389,7 @@ extension SessionExplorerWindowController: NSTableViewDataSource, NSTableViewDel
 
         // Timestamp + message count
         let timeStr = relativeFormatter.localizedString(for: session.modificationDate, relativeTo: Date())
-        let metaText = session.messageCount > 0 ? "\(timeStr) \u{00B7} \(session.messageCount) msgs" : timeStr
+        let metaText = timeStr
         let metaField = NSTextField(labelWithString: metaText)
         metaField.font = .systemFont(ofSize: 10)
         metaField.textColor = .tertiaryLabelColor

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -160,19 +160,16 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
         let savedNames = SessionManager.shared.loadSessionNames()
 
         allSessions = rawSessions.map { session in
-            var info = ExplorerSessionInfo(
+            let name = savedNames[session.sessionId]
+            return ExplorerSessionInfo(
                 sessionId: session.sessionId,
                 filePath: URL(fileURLWithPath: NSHomeDirectory() + "/.claude/projects/\(projectPath.claudeProjectDirName)/\(session.sessionId).jsonl"),
                 modificationDate: session.modificationDate,
                 messageCount: session.messageCount,
                 firstUserMessage: session.firstUserMessage,
+                savedName: (name?.isEmpty == false) ? name : nil,
                 summary: SummaryManager.shared.cachedSummary(forSessionId: session.sessionId)
             )
-            // Use saved name as summary if no AI summary
-            if info.summary == nil, let name = savedNames[session.sessionId], !name.isEmpty {
-                info.summary = name
-            }
-            return info
         }
 
         bookmarks = BookmarkManager.shared.bookmarks(forProjectPath: projectPath)
@@ -188,6 +185,7 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
             filteredBookmarks = bookmarks
         } else {
             filteredSessions = allSessions.filter {
+                ($0.savedName ?? "").lowercased().contains(query) ||
                 ($0.summary ?? "").lowercased().contains(query) ||
                 $0.firstUserMessage.lowercased().contains(query)
             }
@@ -517,8 +515,8 @@ extension SessionExplorerWindowController: NSTableViewDataSource, NSTableViewDel
     private func makeSessionCell(session: ExplorerSessionInfo) -> NSView {
         let cell = NSTableCellView()
 
-        // First user message as title
-        let title = NSTextField(labelWithString: session.firstUserMessage)
+        // Saved name as title, falling back to first user message
+        let title = NSTextField(labelWithString: session.savedName ?? session.firstUserMessage)
         title.font = .systemFont(ofSize: 13, weight: session.sessionId == selectedSessionId ? .semibold : .regular)
         title.textColor = .labelColor
         title.lineBreakMode = .byTruncatingTail

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -1,0 +1,505 @@
+import AppKit
+
+/// Displays all Claude Code sessions for a project in a dedicated window.
+/// Left pane: search + bookmarks + session list. Right pane: conversation timeline.
+class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, NSSearchFieldDelegate {
+
+    private let projectPath: String
+    private let projectName: String
+
+    /// Callback invoked when the user picks an action (resume/fork).
+    /// Parameters: sessionId, forkSession flag.
+    var onSessionAction: ((String, Bool) -> Void)?
+
+    // --- Data ---
+    private var allSessions: [ExplorerSessionInfo] = []
+    private var filteredSessions: [ExplorerSessionInfo] = []
+    private var bookmarks: [SessionBookmark] = []
+    private var filteredBookmarks: [SessionBookmark] = []
+    private var selectedSessionId: String?
+
+    // --- UI ---
+    private let splitView = NSSplitView()
+    private let leftPane = NSView()
+    private let rightPane = NSView()
+    private let searchField = NSSearchField()
+    private let listScrollView = NSScrollView()
+    private let listTableView = NSTableView()
+
+    // Right pane managed by timeline view helper
+    private var timelineController: SessionExplorerTimelineController?
+
+    // --- Formatters ---
+    private let relativeFormatter: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter()
+        f.unitsStyle = .abbreviated
+        return f
+    }()
+
+    init(projectPath: String, projectName: String) {
+        self.projectPath = projectPath
+        self.projectName = projectName
+
+        let colors = ThemeManager.shared.currentColors
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 900, height: 600),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Sessions — \(projectName)"
+        window.minSize = NSSize(width: 700, height: 500)
+        window.backgroundColor = colors.background
+        window.titlebarAppearsTransparent = true
+        window.appearance = NSAppearance(named: colors.isDark ? .darkAqua : .aqua)
+
+        super.init(window: window)
+        window.delegate = self
+        window.setFrameAutosaveName("SessionExplorerWindow")
+        window.center()
+
+        setupUI()
+        loadData()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        guard let contentView = window?.contentView else { return }
+
+        // Split view
+        splitView.isVertical = true
+        splitView.dividerStyle = .thin
+        splitView.delegate = self
+        splitView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(splitView)
+        NSLayoutConstraint.activate([
+            splitView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            splitView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            splitView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            splitView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+        ])
+
+        // Left pane
+        setupLeftPane()
+        splitView.addSubview(leftPane)
+
+        // Right pane
+        setupRightPane()
+        splitView.addSubview(rightPane)
+
+        splitView.setPosition(310, ofDividerAt: 0)
+    }
+
+    private func setupLeftPane() {
+        leftPane.translatesAutoresizingMaskIntoConstraints = false
+
+        // Search field
+        searchField.placeholderString = "Search sessions..."
+        searchField.translatesAutoresizingMaskIntoConstraints = false
+        searchField.delegate = self
+        searchField.sendsSearchStringImmediately = true
+        searchField.sendsWholeSearchString = false
+        leftPane.addSubview(searchField)
+
+        // Table view
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("session"))
+        column.title = ""
+        listTableView.addTableColumn(column)
+        listTableView.headerView = nil
+        listTableView.dataSource = self
+        listTableView.delegate = self
+        listTableView.rowHeight = 52
+        listTableView.backgroundColor = .clear
+        listTableView.selectionHighlightStyle = .regular
+        listTableView.target = self
+        listTableView.action = #selector(listRowClicked)
+
+        listScrollView.documentView = listTableView
+        listScrollView.hasVerticalScroller = true
+        listScrollView.translatesAutoresizingMaskIntoConstraints = false
+        listScrollView.drawsBackground = false
+        leftPane.addSubview(listScrollView)
+
+        NSLayoutConstraint.activate([
+            searchField.topAnchor.constraint(equalTo: leftPane.topAnchor, constant: 8),
+            searchField.leadingAnchor.constraint(equalTo: leftPane.leadingAnchor, constant: 8),
+            searchField.trailingAnchor.constraint(equalTo: leftPane.trailingAnchor, constant: -8),
+
+            listScrollView.topAnchor.constraint(equalTo: searchField.bottomAnchor, constant: 8),
+            listScrollView.leadingAnchor.constraint(equalTo: leftPane.leadingAnchor),
+            listScrollView.trailingAnchor.constraint(equalTo: leftPane.trailingAnchor),
+            listScrollView.bottomAnchor.constraint(equalTo: leftPane.bottomAnchor),
+        ])
+    }
+
+    private func setupRightPane() {
+        rightPane.translatesAutoresizingMaskIntoConstraints = false
+        timelineController = SessionExplorerTimelineController(containerView: rightPane)
+        timelineController?.onResume = { [weak self] sessionId in
+            self?.performAction(sessionId: sessionId, fork: false)
+        }
+        timelineController?.onFork = { [weak self] sessionId in
+            self?.performAction(sessionId: sessionId, fork: true)
+        }
+        timelineController?.onForkAtPoint = { [weak self] sessionId, turnIndex in
+            self?.performForkAtPoint(sessionId: sessionId, turnIndex: turnIndex)
+        }
+        timelineController?.onBookmarkToggle = { [weak self] sessionId, entry in
+            self?.toggleBookmark(sessionId: sessionId, entry: entry)
+        }
+    }
+
+    // MARK: - Data Loading
+
+    private func loadData() {
+        let rawSessions = ContextMonitor.shared.listSessions(forProjectPath: projectPath)
+        let savedNames = SessionManager.shared.loadSessionNames()
+
+        allSessions = rawSessions.map { session in
+            var info = ExplorerSessionInfo(
+                sessionId: session.sessionId,
+                filePath: URL(fileURLWithPath: NSHomeDirectory() + "/.claude/projects/\(projectPath.claudeProjectDirName)/\(session.sessionId).jsonl"),
+                modificationDate: session.modificationDate,
+                messageCount: session.messageCount,
+                firstUserMessage: session.firstUserMessage,
+                summary: SummaryManager.shared.cachedSummary(forSessionId: session.sessionId)
+            )
+            // Use saved name as summary if no AI summary
+            if info.summary == nil, let name = savedNames[session.sessionId], !name.isEmpty {
+                info.summary = name
+            }
+            return info
+        }
+
+        bookmarks = BookmarkManager.shared.bookmarks(forProjectPath: projectPath)
+            .sorted { $0.createdAt < $1.createdAt }
+
+        applyFilter()
+    }
+
+    private func applyFilter() {
+        let query = searchField.stringValue.lowercased()
+        if query.isEmpty {
+            filteredSessions = allSessions
+            filteredBookmarks = bookmarks
+        } else {
+            filteredSessions = allSessions.filter {
+                ($0.summary ?? "").lowercased().contains(query) ||
+                $0.firstUserMessage.lowercased().contains(query)
+            }
+            filteredBookmarks = bookmarks.filter {
+                $0.label.lowercased().contains(query)
+            }
+        }
+        listTableView.reloadData()
+    }
+
+    // MARK: - Actions
+
+    private func performAction(sessionId: String, fork: Bool) {
+        onSessionAction?(sessionId, fork)
+        close()
+    }
+
+    private func performForkAtPoint(sessionId: String, turnIndex: Int) {
+        guard let newSessionId = ContextMonitor.shared.truncateSession(
+            sessionId: sessionId,
+            projectPath: projectPath,
+            afterTurnIndex: turnIndex
+        ) else { return }
+
+        onSessionAction?(newSessionId, true)
+        close()
+    }
+
+    private func toggleBookmark(sessionId: String, entry: TimelineEntry) {
+        if entry.isBookmarked {
+            BookmarkManager.shared.removeBookmark(
+                projectPath: projectPath,
+                sessionId: sessionId,
+                messageIndex: entry.index
+            )
+        } else {
+            promptForBookmarkLabel(defaultLabel: String(entry.message.prefix(60))) { [weak self] label in
+                guard let self, let label else { return }
+                BookmarkManager.shared.addBookmark(
+                    projectPath: self.projectPath,
+                    sessionId: sessionId,
+                    messageIndex: entry.index,
+                    label: label
+                )
+                self.loadData()
+                self.timelineController?.reloadBookmarkState(
+                    projectPath: self.projectPath,
+                    sessionId: sessionId
+                )
+            }
+            return
+        }
+        loadData()
+        timelineController?.reloadBookmarkState(projectPath: projectPath, sessionId: sessionId)
+    }
+
+    private func promptForBookmarkLabel(defaultLabel: String, completion: @escaping (String?) -> Void) {
+        let alert = NSAlert()
+        alert.messageText = "Bookmark Label"
+        alert.informativeText = "Enter a name for this bookmark:"
+        alert.addButton(withTitle: "Save")
+        alert.addButton(withTitle: "Cancel")
+
+        let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 300, height: 24))
+        input.stringValue = defaultLabel
+        alert.accessoryView = input
+
+        alert.beginSheetModal(for: window!) { response in
+            if response == .alertFirstButtonReturn {
+                let label = input.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                completion(label.isEmpty ? defaultLabel : label)
+            } else {
+                completion(nil)
+            }
+        }
+    }
+
+    // MARK: - Search
+
+    func controlTextDidChange(_ obj: Notification) {
+        if (obj.object as? NSSearchField) === searchField {
+            applyFilter()
+        }
+    }
+
+    // MARK: - List selection
+
+    @objc private func listRowClicked() {
+        let row = listTableView.selectedRow
+        guard row >= 0 else { return }
+
+        let bookmarkCount = filteredBookmarks.count
+        let hasDivider = bookmarkCount > 0
+
+        if row < bookmarkCount {
+            // Clicked a bookmark -- select its parent session and scroll to message
+            let bookmark = filteredBookmarks[row]
+            selectSession(sessionId: bookmark.sessionId, scrollToMessageIndex: bookmark.messageIndex)
+        } else {
+            let sessionIndex = row - bookmarkCount - (hasDivider ? 1 : 0)
+            guard sessionIndex >= 0, sessionIndex < filteredSessions.count else { return }
+            let session = filteredSessions[sessionIndex]
+            selectSession(sessionId: session.sessionId, scrollToMessageIndex: nil)
+        }
+    }
+
+    private func selectSession(sessionId: String, scrollToMessageIndex: Int?) {
+        selectedSessionId = sessionId
+        guard let session = allSessions.first(where: { $0.sessionId == sessionId }) else { return }
+
+        // Trigger summary generation if needed
+        if session.summary == nil {
+            SummaryManager.shared.generateSummary(sessionId: sessionId, projectPath: projectPath) { [weak self] summary in
+                guard let self else { return }
+                if let idx = self.allSessions.firstIndex(where: { $0.sessionId == sessionId }), let summary {
+                    self.allSessions[idx].summary = summary
+                    self.applyFilter()
+                }
+            }
+        }
+
+        let entries = ContextMonitor.shared.parseTimeline(sessionId: sessionId, projectPath: projectPath)
+        // Enrich entries with bookmark state
+        let enrichedEntries = entries.map { entry -> TimelineEntry in
+            var e = entry
+            e.isBookmarked = BookmarkManager.shared.isBookmarked(
+                projectPath: projectPath,
+                sessionId: sessionId,
+                messageIndex: entry.index
+            )
+            e.bookmarkLabel = BookmarkManager.shared.bookmarkLabel(
+                projectPath: projectPath,
+                sessionId: sessionId,
+                messageIndex: entry.index
+            )
+            return e
+        }
+
+        timelineController?.showTimeline(
+            session: session,
+            entries: enrichedEntries,
+            scrollToIndex: scrollToMessageIndex
+        )
+    }
+
+    // MARK: - NSSplitViewDelegate
+
+    func splitView(_ splitView: NSSplitView, constrainMinCoordinate proposedMinimumPosition: CGFloat, ofSubviewAt dividerIndex: Int) -> CGFloat {
+        return 200
+    }
+
+    func splitView(_ splitView: NSSplitView, constrainMaxCoordinate proposedMaximumPosition: CGFloat, ofSubviewAt dividerIndex: Int) -> CGFloat {
+        return (window?.frame.width ?? 900) * 0.5
+    }
+}
+
+// MARK: - NSTableViewDataSource & Delegate (left pane list)
+
+extension SessionExplorerWindowController: NSTableViewDataSource, NSTableViewDelegate {
+
+    /// Total rows = bookmarks + (divider if bookmarks exist) + sessions
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        let bookmarkCount = filteredBookmarks.count
+        let divider = bookmarkCount > 0 ? 1 : 0
+        return bookmarkCount + divider + filteredSessions.count
+    }
+
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        let bookmarkCount = filteredBookmarks.count
+        let hasDivider = bookmarkCount > 0
+
+        if row < bookmarkCount {
+            // Bookmark row
+            let bookmark = filteredBookmarks[row]
+            let sessionSummary = allSessions.first(where: { $0.sessionId == bookmark.sessionId })
+            return makeBookmarkCell(bookmark: bookmark, sessionSummary: sessionSummary?.summary ?? sessionSummary?.firstUserMessage ?? "")
+        } else if hasDivider && row == bookmarkCount {
+            // Divider row
+            return makeDividerCell()
+        } else {
+            // Session row
+            let sessionIndex = row - bookmarkCount - (hasDivider ? 1 : 0)
+            guard sessionIndex >= 0, sessionIndex < filteredSessions.count else { return nil }
+            let session = filteredSessions[sessionIndex]
+            return makeSessionCell(session: session)
+        }
+    }
+
+    func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
+        let bookmarkCount = filteredBookmarks.count
+        let hasDivider = bookmarkCount > 0
+        if hasDivider && row == bookmarkCount { return 16 }  // divider
+        return 52
+    }
+
+    func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool {
+        // Don't allow selecting the divider
+        let bookmarkCount = filteredBookmarks.count
+        let hasDivider = bookmarkCount > 0
+        if hasDivider && row == bookmarkCount { return false }
+        return true
+    }
+
+    // MARK: - Cell Factories
+
+    private func makeBookmarkCell(bookmark: SessionBookmark, sessionSummary: String) -> NSView {
+        let cell = NSTableCellView()
+        cell.wantsLayer = true
+        cell.layer?.backgroundColor = NSColor(red: 1.0, green: 0.85, blue: 0.2, alpha: 0.08).cgColor
+        cell.layer?.cornerRadius = 4
+
+        let star = NSTextField(labelWithString: "\u{2605}")
+        star.font = .systemFont(ofSize: 12)
+        star.textColor = NSColor(red: 1.0, green: 0.8, blue: 0.2, alpha: 0.7)
+        star.translatesAutoresizingMaskIntoConstraints = false
+
+        let title = NSTextField(labelWithString: bookmark.label)
+        title.font = .systemFont(ofSize: 13, weight: .semibold)
+        title.textColor = .labelColor
+        title.lineBreakMode = .byTruncatingTail
+        title.translatesAutoresizingMaskIntoConstraints = false
+
+        let subtitle = NSTextField(labelWithString: "\(sessionSummary) \u{00B7} msg \(bookmark.messageIndex + 1)")
+        subtitle.font = .systemFont(ofSize: 11)
+        subtitle.textColor = .secondaryLabelColor
+        subtitle.lineBreakMode = .byTruncatingTail
+        subtitle.translatesAutoresizingMaskIntoConstraints = false
+
+        cell.addSubview(star)
+        cell.addSubview(title)
+        cell.addSubview(subtitle)
+
+        NSLayoutConstraint.activate([
+            star.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 8),
+            star.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+
+            title.leadingAnchor.constraint(equalTo: star.trailingAnchor, constant: 4),
+            title.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -8),
+            title.topAnchor.constraint(equalTo: cell.topAnchor, constant: 8),
+
+            subtitle.leadingAnchor.constraint(equalTo: title.leadingAnchor),
+            subtitle.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -8),
+            subtitle.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 2),
+        ])
+
+        return cell
+    }
+
+    private func makeDividerCell() -> NSView {
+        let cell = NSView()
+        let line = NSBox()
+        line.boxType = .separator
+        line.translatesAutoresizingMaskIntoConstraints = false
+        cell.addSubview(line)
+        NSLayoutConstraint.activate([
+            line.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 8),
+            line.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -8),
+            line.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+        ])
+        return cell
+    }
+
+    private func makeSessionCell(session: ExplorerSessionInfo) -> NSView {
+        let cell = NSTableCellView()
+
+        let title = NSTextField(labelWithString: session.summary ?? session.firstUserMessage)
+        title.font = .systemFont(ofSize: 13, weight: session.sessionId == selectedSessionId ? .semibold : .regular)
+        title.textColor = .labelColor
+        title.lineBreakMode = .byTruncatingTail
+        title.translatesAutoresizingMaskIntoConstraints = false
+
+        let timeStr = relativeFormatter.localizedString(for: session.modificationDate, relativeTo: Date())
+        let subtitle = NSTextField(labelWithString: "\(timeStr) \u{00B7} \(session.messageCount) msgs")
+        subtitle.font = .systemFont(ofSize: 11)
+        subtitle.textColor = .secondaryLabelColor
+        subtitle.translatesAutoresizingMaskIntoConstraints = false
+
+        // Spinner for summary generation
+        let spinner = NSProgressIndicator()
+        spinner.style = .spinning
+        spinner.controlSize = .small
+        spinner.translatesAutoresizingMaskIntoConstraints = false
+        spinner.isHidden = !SummaryManager.shared.isGenerating(sessionId: session.sessionId)
+        if !spinner.isHidden { spinner.startAnimation(nil) }
+
+        cell.addSubview(title)
+        cell.addSubview(subtitle)
+        cell.addSubview(spinner)
+
+        NSLayoutConstraint.activate([
+            title.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 12),
+            title.trailingAnchor.constraint(equalTo: spinner.leadingAnchor, constant: -4),
+            title.topAnchor.constraint(equalTo: cell.topAnchor, constant: 8),
+
+            subtitle.leadingAnchor.constraint(equalTo: title.leadingAnchor),
+            subtitle.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -12),
+            subtitle.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 2),
+
+            spinner.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -12),
+            spinner.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+            spinner.widthAnchor.constraint(equalToConstant: 16),
+            spinner.heightAnchor.constraint(equalToConstant: 16),
+        ])
+
+        return cell
+    }
+}
+
+// MARK: - NSWindowDelegate
+
+extension SessionExplorerWindowController: NSWindowDelegate {
+    func windowWillClose(_ notification: Notification) {
+        // Allow deallocation
+    }
+}

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -354,52 +354,33 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
         // Load cached action summaries (no AI call — just what we already have)
         let cachedActionSummaries = SummaryManager.shared.cachedTurnSummaries(forSessionId: sessionId)
 
-        // Check if there are uncached turns that could be summarized
+        // Check if anything needs AI summarization
         let actions = ContextMonitor.shared.parseActions(sessionId: sessionId, projectPath: projectPath)
         let hasUncachedActions = entries.contains { entry in
             let turnActions = actions[entry.index] ?? []
             return !turnActions.isEmpty && cachedActionSummaries[entry.index] == nil
         }
-
-        // Check if session summary needs (re)generation
         let cachedTurnCount = SummaryManager.shared.cachedSummaryTurnCount(forSessionId: sessionId)
         let needsSessionSummary = session.summary == nil || cachedTurnCount < entries.count
+        let needsSummarization = needsSessionSummary || hasUncachedActions
 
         timelineController?.showTimeline(
             session: updatedSession,
             entries: enrichedEntries,
             cachedActionSummaries: cachedActionSummaries,
-            showSummarizeButton: needsSessionSummary,
-            showSummarizeActionsButton: hasUncachedActions,
+            showSummarizeButton: needsSummarization,
             scrollToIndex: scrollToMessageIndex
         )
 
-        timelineController?.onSummarizeSession = { [weak self] in
-            self?.summarizeSession(sessionId: sessionId)
-        }
-        timelineController?.onSummarizeActions = { [weak self] in
-            self?.summarizeActions(sessionId: sessionId, entries: entries, actions: actions)
+        timelineController?.onSummarize = { [weak self] in
+            self?.summarizeAll(sessionId: sessionId, entries: entries, actions: actions)
         }
     }
 
-    private func summarizeSession(sessionId: String) {
+    private func summarizeAll(sessionId: String, entries: [TimelineEntry], actions: [Int: [String]]) {
         guard let session = allSessions.first(where: { $0.sessionId == sessionId }) else { return }
-        let turnCount = session.messageCount
 
-        SummaryManager.shared.generateSummary(sessionId: sessionId, projectPath: projectPath, currentTurnCount: turnCount) { [weak self] summary in
-            guard let self else { return }
-            if let idx = self.allSessions.firstIndex(where: { $0.sessionId == sessionId }), let summary {
-                self.allSessions[idx].summary = summary
-                self.applyFilter()
-                if self.selectedSessionId == sessionId {
-                    self.timelineController?.updateHeaderSummary(summary)
-                    self.timelineController?.hideSummarizeSessionButton()
-                }
-            }
-        }
-    }
-
-    private func summarizeActions(sessionId: String, entries: [TimelineEntry], actions: [Int: [String]]) {
+        // Show spinners on uncached action turns
         let cached = SummaryManager.shared.cachedTurnSummaries(forSessionId: sessionId)
         let uncachedTurns = Set(entries.map { $0.index }.filter {
             actions[$0] != nil && !actions[$0]!.isEmpty && cached[$0] == nil
@@ -407,10 +388,25 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
         if !uncachedTurns.isEmpty {
             timelineController?.setGeneratingTurns(uncachedTurns)
         }
-        SummaryManager.shared.generateTurnSummaries(sessionId: sessionId, actions: actions) { [weak self] summaries in
+
+        // Single combined AI call for both session summary + action summaries
+        SummaryManager.shared.generateCombinedSummaries(
+            sessionId: sessionId,
+            projectPath: projectPath,
+            currentTurnCount: entries.count,
+            actions: actions
+        ) { [weak self] sessionSummary, actionSummaries in
             guard let self, self.selectedSessionId == sessionId else { return }
-            self.timelineController?.updateActionSummaries(summaries)
-            self.timelineController?.hideSummarizeActionsButton()
+
+            if let summary = sessionSummary,
+               let idx = self.allSessions.firstIndex(where: { $0.sessionId == sessionId }) {
+                self.allSessions[idx].summary = summary
+                self.applyFilter()
+                self.timelineController?.updateHeaderSummary(summary)
+            }
+
+            self.timelineController?.updateActionSummaries(actionSummaries)
+            self.timelineController?.hideSummarizeButton()
         }
     }
 

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -314,6 +314,16 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
         }
 
         let entries = ContextMonitor.shared.parseTimeline(sessionId: sessionId, projectPath: projectPath)
+
+        // Update message count now that we've parsed the full file
+        if let idx = allSessions.firstIndex(where: { $0.sessionId == sessionId }), allSessions[idx].messageCount == 0 {
+            allSessions[idx].messageCount = entries.count
+            applyFilter()
+        }
+
+        // Use the session with updated messageCount for the timeline header
+        let updatedSession = allSessions.first(where: { $0.sessionId == sessionId }) ?? session
+
         // Enrich entries with bookmark state
         let enrichedEntries = entries.map { entry -> TimelineEntry in
             var e = entry
@@ -331,7 +341,7 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
         }
 
         timelineController?.showTimeline(
-            session: session,
+            session: updatedSession,
             entries: enrichedEntries,
             scrollToIndex: scrollToMessageIndex
         )
@@ -464,7 +474,8 @@ extension SessionExplorerWindowController: NSTableViewDataSource, NSTableViewDel
         title.translatesAutoresizingMaskIntoConstraints = false
 
         let timeStr = relativeFormatter.localizedString(for: session.modificationDate, relativeTo: Date())
-        let subtitle = NSTextField(labelWithString: "\(timeStr) \u{00B7} \(session.messageCount) msgs")
+        let subtitleText = session.messageCount > 0 ? "\(timeStr) \u{00B7} \(session.messageCount) msgs" : timeStr
+        let subtitle = NSTextField(labelWithString: subtitleText)
         subtitle.font = .systemFont(ofSize: 11)
         subtitle.textColor = .secondaryLabelColor
         subtitle.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -1,7 +1,7 @@
 import AppKit
 
 /// Displays all Claude Code sessions for a project in a dedicated window.
-/// Left pane: search + bookmarks + session list. Right pane: conversation timeline.
+/// Left pane: search + session list with star toggles. Right pane: conversation timeline.
 class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, NSSearchFieldDelegate {
 
     private let projectPath: String
@@ -14,9 +14,8 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
     // --- Data ---
     private var allSessions: [ExplorerSessionInfo] = []
     private var filteredSessions: [ExplorerSessionInfo] = []
-    private var bookmarks: [SessionBookmark] = []
-    private var filteredBookmarks: [SessionBookmark] = []
     private var selectedSessionId: String?
+    private var showFavoritesOnly = false
 
     // --- UI ---
     private let splitView = NSSplitView()
@@ -70,7 +69,6 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
     private func setupUI() {
         guard let contentView = window?.contentView else { return }
 
-        // Split view
         splitView.isVertical = true
         splitView.dividerStyle = .thin
         splitView.delegate = self
@@ -83,11 +81,9 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
             splitView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
         ])
 
-        // Left pane
         setupLeftPane()
         splitView.addSubview(leftPane)
 
-        // Right pane
         setupRightPane()
         splitView.addSubview(rightPane)
 
@@ -97,7 +93,6 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
     private func setupLeftPane() {
         leftPane.translatesAutoresizingMaskIntoConstraints = false
 
-        // Search field
         searchField.placeholderString = "Search sessions..."
         searchField.translatesAutoresizingMaskIntoConstraints = false
         searchField.delegate = self
@@ -105,7 +100,14 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
         searchField.sendsWholeSearchString = false
         leftPane.addSubview(searchField)
 
-        // Table view
+        let favBtn = NSButton(title: "", target: self, action: #selector(toggleFavoritesFilter))
+        favBtn.image = NSImage(systemSymbolName: "star", accessibilityDescription: "Show favorites only")
+        favBtn.bezelStyle = .inline
+        favBtn.isBordered = false
+        favBtn.toolTip = "Show favorites only"
+        favBtn.translatesAutoresizingMaskIntoConstraints = false
+        leftPane.addSubview(favBtn)
+
         let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("session"))
         column.title = ""
         listTableView.addTableColumn(column)
@@ -127,7 +129,11 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
         NSLayoutConstraint.activate([
             searchField.topAnchor.constraint(equalTo: leftPane.topAnchor, constant: 8),
             searchField.leadingAnchor.constraint(equalTo: leftPane.leadingAnchor, constant: 8),
-            searchField.trailingAnchor.constraint(equalTo: leftPane.trailingAnchor, constant: -8),
+            searchField.trailingAnchor.constraint(equalTo: favBtn.leadingAnchor, constant: -4),
+
+            favBtn.centerYAnchor.constraint(equalTo: searchField.centerYAnchor),
+            favBtn.trailingAnchor.constraint(equalTo: leftPane.trailingAnchor, constant: -8),
+            favBtn.widthAnchor.constraint(equalToConstant: 24),
 
             listScrollView.topAnchor.constraint(equalTo: searchField.bottomAnchor, constant: 8),
             listScrollView.leadingAnchor.constraint(equalTo: leftPane.leadingAnchor),
@@ -148,9 +154,6 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
         timelineController?.onForkAtPoint = { [weak self] sessionId, turnIndex in
             self?.performForkAtPoint(sessionId: sessionId, turnIndex: turnIndex)
         }
-        timelineController?.onBookmarkToggle = { [weak self] sessionId, entry in
-            self?.toggleBookmark(sessionId: sessionId, entry: entry)
-        }
     }
 
     // MARK: - Data Loading
@@ -158,6 +161,7 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
     private func loadData() {
         let rawSessions = ContextMonitor.shared.listSessions(forProjectPath: projectPath)
         let savedNames = SessionManager.shared.loadSessionNames()
+        let bookmarkedIds = BookmarkManager.shared.bookmarkedSessionIds(forProjectPath: projectPath)
 
         allSessions = rawSessions.map { session in
             let name = savedNames[session.sessionId]
@@ -168,32 +172,41 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
                 messageCount: session.messageCount,
                 firstUserMessage: session.firstUserMessage,
                 savedName: (name?.isEmpty == false) ? name : nil,
-                summary: SummaryManager.shared.cachedSummary(forSessionId: session.sessionId)
+                summary: SummaryManager.shared.cachedSummary(forSessionId: session.sessionId),
+                isBookmarked: bookmarkedIds.contains(session.sessionId)
             )
         }
 
-        bookmarks = BookmarkManager.shared.bookmarks(forProjectPath: projectPath)
-            .sorted { $0.createdAt < $1.createdAt }
+        applyFilter()
+    }
 
+    @objc private func toggleFavoritesFilter(_ sender: NSButton) {
+        showFavoritesOnly.toggle()
+        sender.contentTintColor = showFavoritesOnly
+            ? NSColor(red: 1.0, green: 0.8, blue: 0.2, alpha: 0.9)
+            : nil
+        sender.image = NSImage(systemSymbolName: showFavoritesOnly ? "star.fill" : "star", accessibilityDescription: "Show favorites only")
         applyFilter()
     }
 
     private func applyFilter() {
         let query = searchField.stringValue.lowercased()
-        if query.isEmpty {
-            filteredSessions = allSessions
-            filteredBookmarks = bookmarks
-        } else {
-            filteredSessions = allSessions.filter {
+        var sessions = allSessions
+
+        if showFavoritesOnly {
+            sessions = sessions.filter { $0.isBookmarked }
+        }
+
+        if !query.isEmpty {
+            sessions = sessions.filter {
                 ($0.savedName ?? "").lowercased().contains(query) ||
                 ($0.summary ?? "").lowercased().contains(query) ||
                 $0.firstUserMessage.lowercased().contains(query)
             }
-            filteredBookmarks = bookmarks.filter {
-                $0.label.lowercased().contains(query)
-            }
         }
-        // Preserve selection across reload
+
+        filteredSessions = sessions
+
         let previousSelection = selectedSessionId
         listTableView.reloadData()
         if let prevId = previousSelection {
@@ -201,20 +214,15 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
         }
     }
 
-    /// Restores the list selection to match the given sessionId.
     private func restoreListSelection(sessionId: String) {
-        let bookmarkCount = filteredBookmarks.count
-        let hasDivider = bookmarkCount > 0
-        let offset = bookmarkCount + (hasDivider ? 1 : 0)
         if let idx = filteredSessions.firstIndex(where: { $0.sessionId == sessionId }) {
-            listTableView.selectRowIndexes(IndexSet(integer: offset + idx), byExtendingSelection: false)
+            listTableView.selectRowIndexes(IndexSet(integer: idx), byExtendingSelection: false)
         }
     }
 
     // MARK: - Actions
 
     private func sessionDisplayName(for sessionId: String) -> String? {
-        // Prefer saved session name (from tab rename), then first user message
         let savedNames = SessionManager.shared.loadSessionNames()
         if let name = savedNames[sessionId], !name.isEmpty { return name }
         guard let session = allSessions.first(where: { $0.sessionId == sessionId }) else { return nil }
@@ -239,57 +247,13 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
         close()
     }
 
-    private func toggleBookmark(sessionId: String, entry: TimelineEntry) {
-        if entry.isBookmarked {
-            BookmarkManager.shared.removeBookmark(
-                projectPath: projectPath,
-                sessionId: sessionId,
-                messageIndex: entry.index
-            )
-        } else {
-            promptForBookmarkLabel(defaultLabel: String(entry.message.prefix(60))) { [weak self] label in
-                guard let self, let label else { return }
-                BookmarkManager.shared.addBookmark(
-                    projectPath: self.projectPath,
-                    sessionId: sessionId,
-                    messageIndex: entry.index,
-                    label: label
-                )
-                self.loadData()
-                self.timelineController?.reloadBookmarkState(
-                    projectPath: self.projectPath,
-                    sessionId: sessionId
-                )
-            }
-            return
+    @objc private func starClicked(_ sender: NSButton) {
+        let sessionId = filteredSessions[sender.tag].sessionId
+        let newState = BookmarkManager.shared.toggleBookmark(projectPath: projectPath, sessionId: sessionId)
+        if let idx = allSessions.firstIndex(where: { $0.sessionId == sessionId }) {
+            allSessions[idx].isBookmarked = newState
         }
-        loadData()
-        timelineController?.reloadBookmarkState(projectPath: projectPath, sessionId: sessionId)
-    }
-
-    private func promptForBookmarkLabel(defaultLabel: String, completion: @escaping (String?) -> Void) {
-        guard let window else {
-            completion(nil)
-            return
-        }
-        let alert = NSAlert()
-        alert.messageText = "Bookmark Label"
-        alert.informativeText = "Enter a name for this bookmark:"
-        alert.addButton(withTitle: "Save")
-        alert.addButton(withTitle: "Cancel")
-
-        let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 300, height: 24))
-        input.stringValue = defaultLabel
-        alert.accessoryView = input
-
-        alert.beginSheetModal(for: window) { response in
-            if response == .alertFirstButtonReturn {
-                let label = input.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-                completion(label.isEmpty ? defaultLabel : label)
-            } else {
-                completion(nil)
-            }
-        }
+        applyFilter()
     }
 
     // MARK: - Search
@@ -304,21 +268,9 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
 
     @objc private func listRowClicked() {
         let row = listTableView.selectedRow
-        guard row >= 0 else { return }
-
-        let bookmarkCount = filteredBookmarks.count
-        let hasDivider = bookmarkCount > 0
-
-        if row < bookmarkCount {
-            // Clicked a bookmark -- select its parent session and scroll to message
-            let bookmark = filteredBookmarks[row]
-            selectSession(sessionId: bookmark.sessionId, scrollToMessageIndex: bookmark.messageIndex)
-        } else {
-            let sessionIndex = row - bookmarkCount - (hasDivider ? 1 : 0)
-            guard sessionIndex >= 0, sessionIndex < filteredSessions.count else { return }
-            let session = filteredSessions[sessionIndex]
-            selectSession(sessionId: session.sessionId, scrollToMessageIndex: nil)
-        }
+        guard row >= 0, row < filteredSessions.count else { return }
+        let session = filteredSessions[row]
+        selectSession(sessionId: session.sessionId, scrollToMessageIndex: nil)
     }
 
     private func selectSession(sessionId: String, scrollToMessageIndex: Int?) {
@@ -327,34 +279,14 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
 
         let entries = ContextMonitor.shared.parseTimeline(sessionId: sessionId, projectPath: projectPath)
 
-        // Update message count now that we've parsed the full file
         if let idx = allSessions.firstIndex(where: { $0.sessionId == sessionId }) {
             allSessions[idx].messageCount = entries.count
         }
 
-        // Use the session with updated messageCount for the timeline header
         let updatedSession = allSessions.first(where: { $0.sessionId == sessionId }) ?? session
 
-        // Enrich entries with bookmark state
-        let enrichedEntries = entries.map { entry -> TimelineEntry in
-            var e = entry
-            e.isBookmarked = BookmarkManager.shared.isBookmarked(
-                projectPath: projectPath,
-                sessionId: sessionId,
-                messageIndex: entry.index
-            )
-            e.bookmarkLabel = BookmarkManager.shared.bookmarkLabel(
-                projectPath: projectPath,
-                sessionId: sessionId,
-                messageIndex: entry.index
-            )
-            return e
-        }
-
-        // Load cached action summaries (no AI call — just what we already have)
         let cachedActionSummaries = SummaryManager.shared.cachedTurnSummaries(forSessionId: sessionId)
 
-        // Check if anything needs AI summarization
         let actions = ContextMonitor.shared.parseActions(sessionId: sessionId, projectPath: projectPath)
         let hasUncachedActions = entries.contains { entry in
             let turnActions = actions[entry.index] ?? []
@@ -366,7 +298,7 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
 
         timelineController?.showTimeline(
             session: updatedSession,
-            entries: enrichedEntries,
+            entries: entries,
             cachedActionSummaries: cachedActionSummaries,
             summarizeEnabled: summarizeEnabled,
             scrollToIndex: scrollToMessageIndex
@@ -394,7 +326,6 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
                 self.applyFilter()
             }
 
-            // Rebuild the entire right pane with updated data
             self.selectSession(sessionId: sessionId, scrollToMessageIndex: nil)
         }
     }
@@ -414,118 +345,36 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
 
 extension SessionExplorerWindowController: NSTableViewDataSource, NSTableViewDelegate {
 
-    /// Total rows = bookmarks + (divider if bookmarks exist) + sessions
     func numberOfRows(in tableView: NSTableView) -> Int {
-        let bookmarkCount = filteredBookmarks.count
-        let divider = bookmarkCount > 0 ? 1 : 0
-        return bookmarkCount + divider + filteredSessions.count
+        filteredSessions.count
     }
 
     func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
-        let bookmarkCount = filteredBookmarks.count
-        let hasDivider = bookmarkCount > 0
+        guard row < filteredSessions.count else { return nil }
+        return makeSessionCell(session: filteredSessions[row], row: row)
+    }
 
-        if row < bookmarkCount {
-            // Bookmark row
-            let bookmark = filteredBookmarks[row]
-            let sessionSummary = allSessions.first(where: { $0.sessionId == bookmark.sessionId })
-            return makeBookmarkCell(bookmark: bookmark, sessionSummary: sessionSummary?.summary ?? sessionSummary?.firstUserMessage ?? "")
-        } else if hasDivider && row == bookmarkCount {
-            // Divider row
-            return makeDividerCell()
-        } else {
-            // Session row
-            let sessionIndex = row - bookmarkCount - (hasDivider ? 1 : 0)
-            guard sessionIndex >= 0, sessionIndex < filteredSessions.count else { return nil }
-            let session = filteredSessions[sessionIndex]
-            return makeSessionCell(session: session)
+    private func makeSessionCell(session: ExplorerSessionInfo, row: Int) -> NSView {
+        let cell = NSTableCellView()
+
+        if session.isBookmarked {
+            cell.wantsLayer = true
+            cell.layer?.backgroundColor = NSColor(red: 1.0, green: 0.85, blue: 0.2, alpha: 0.06).cgColor
         }
-    }
 
-    func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
-        let bookmarkCount = filteredBookmarks.count
-        let hasDivider = bookmarkCount > 0
-        if hasDivider && row == bookmarkCount { return 16 }  // divider
-        return 64
-    }
+        // Star toggle
+        let starBtn = NSButton(title: session.isBookmarked ? "\u{2605}" : "\u{2606}", target: self, action: #selector(starClicked(_:)))
+        starBtn.bezelStyle = .inline
+        starBtn.isBordered = false
+        starBtn.font = .systemFont(ofSize: 14)
+        starBtn.contentTintColor = session.isBookmarked
+            ? NSColor(red: 1.0, green: 0.8, blue: 0.2, alpha: 0.7)
+            : NSColor.tertiaryLabelColor
+        starBtn.tag = row
+        starBtn.translatesAutoresizingMaskIntoConstraints = false
+        cell.addSubview(starBtn)
 
-    func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool {
-        // Don't allow selecting the divider
-        let bookmarkCount = filteredBookmarks.count
-        let hasDivider = bookmarkCount > 0
-        if hasDivider && row == bookmarkCount { return false }
-        return true
-    }
-
-    // MARK: - Cell Factories
-
-    private func makeBookmarkCell(bookmark: SessionBookmark, sessionSummary: String) -> NSView {
-        let cell = NSTableCellView()
-        cell.wantsLayer = true
-        cell.layer?.backgroundColor = NSColor(red: 1.0, green: 0.85, blue: 0.2, alpha: 0.08).cgColor
-        cell.layer?.cornerRadius = 4
-
-        let star = NSTextField(labelWithString: "\u{2605}")
-        star.font = .systemFont(ofSize: 12)
-        star.textColor = NSColor(red: 1.0, green: 0.8, blue: 0.2, alpha: 0.7)
-        star.translatesAutoresizingMaskIntoConstraints = false
-
-        let title = NSTextField(labelWithString: bookmark.label)
-        title.font = .systemFont(ofSize: 13, weight: .semibold)
-        title.textColor = .labelColor
-        title.lineBreakMode = .byWordWrapping
-        title.maximumNumberOfLines = 2
-        title.preferredMaxLayoutWidth = 200
-        title.cell?.wraps = true
-        title.cell?.isScrollable = false
-        title.translatesAutoresizingMaskIntoConstraints = false
-        title.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-
-        let subtitle = NSTextField(labelWithString: "\(sessionSummary) \u{00B7} msg \(bookmark.messageIndex + 1)")
-        subtitle.font = .systemFont(ofSize: 11)
-        subtitle.textColor = .secondaryLabelColor
-        subtitle.lineBreakMode = .byTruncatingTail
-        subtitle.translatesAutoresizingMaskIntoConstraints = false
-
-        cell.addSubview(star)
-        cell.addSubview(title)
-        cell.addSubview(subtitle)
-
-        NSLayoutConstraint.activate([
-            star.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 8),
-            star.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
-
-            title.leadingAnchor.constraint(equalTo: star.trailingAnchor, constant: 4),
-            title.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -8),
-            title.topAnchor.constraint(equalTo: cell.topAnchor, constant: 8),
-
-            subtitle.leadingAnchor.constraint(equalTo: title.leadingAnchor),
-            subtitle.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -8),
-            subtitle.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 2),
-            subtitle.bottomAnchor.constraint(equalTo: cell.bottomAnchor, constant: -8),
-        ])
-
-        return cell
-    }
-
-    private func makeDividerCell() -> NSView {
-        let cell = NSView()
-        let line = NSBox()
-        line.boxType = .separator
-        line.translatesAutoresizingMaskIntoConstraints = false
-        cell.addSubview(line)
-        NSLayoutConstraint.activate([
-            line.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 8),
-            line.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -8),
-            line.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
-        ])
-        return cell
-    }
-
-    private func makeSessionCell(session: ExplorerSessionInfo) -> NSView {
-        let cell = NSTableCellView()
-
-        // Saved name as title, falling back to first user message
+        // Title
         let title = NSTextField(labelWithString: session.savedName ?? session.firstUserMessage)
         title.font = .systemFont(ofSize: 13, weight: session.sessionId == selectedSessionId ? .semibold : .regular)
         title.textColor = .labelColor
@@ -536,8 +385,18 @@ extension SessionExplorerWindowController: NSTableViewDataSource, NSTableViewDel
         title.cell?.isScrollable = false
         title.translatesAutoresizingMaskIntoConstraints = false
         title.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        cell.addSubview(title)
 
-        // AI-generated summary below the title
+        // Timestamp + message count
+        let timeStr = relativeFormatter.localizedString(for: session.modificationDate, relativeTo: Date())
+        let metaText = session.messageCount > 0 ? "\(timeStr) \u{00B7} \(session.messageCount) msgs" : timeStr
+        let metaField = NSTextField(labelWithString: metaText)
+        metaField.font = .systemFont(ofSize: 10)
+        metaField.textColor = .tertiaryLabelColor
+        metaField.translatesAutoresizingMaskIntoConstraints = false
+        cell.addSubview(metaField)
+
+        // AI summary
         let summaryField: NSTextField?
         if let summary = session.summary {
             let field = NSTextField(labelWithString: summary)
@@ -549,56 +408,34 @@ extension SessionExplorerWindowController: NSTableViewDataSource, NSTableViewDel
             field.cell?.isScrollable = false
             field.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
             field.translatesAutoresizingMaskIntoConstraints = false
+            cell.addSubview(field)
             summaryField = field
         } else {
             summaryField = nil
         }
 
-        // Timestamp + message count
-        let timeStr = relativeFormatter.localizedString(for: session.modificationDate, relativeTo: Date())
-        let metaText = session.messageCount > 0 ? "\(timeStr) \u{00B7} \(session.messageCount) msgs" : timeStr
-        let metaField = NSTextField(labelWithString: metaText)
-        metaField.font = .systemFont(ofSize: 10)
-        metaField.textColor = .tertiaryLabelColor
-        metaField.translatesAutoresizingMaskIntoConstraints = false
-
-        // Spinner for summary generation
-        let spinner = NSProgressIndicator()
-        spinner.style = .spinning
-        spinner.controlSize = .small
-        spinner.translatesAutoresizingMaskIntoConstraints = false
-        spinner.isHidden = !SummaryManager.shared.isGenerating(sessionId: session.sessionId)
-        if !spinner.isHidden { spinner.startAnimation(nil) }
-
-        cell.addSubview(title)
-        cell.addSubview(metaField)
-        if let summaryField { cell.addSubview(summaryField) }
-        cell.addSubview(spinner)
-
-        // Bottom anchor: summary if present, otherwise meta
         let bottomView: NSView = summaryField ?? metaField
 
         NSLayoutConstraint.activate([
-            title.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 12),
-            title.trailingAnchor.constraint(equalTo: spinner.leadingAnchor, constant: -4),
+            starBtn.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 4),
+            starBtn.topAnchor.constraint(equalTo: cell.topAnchor, constant: 8),
+            starBtn.widthAnchor.constraint(equalToConstant: 20),
+
+            title.leadingAnchor.constraint(equalTo: starBtn.trailingAnchor, constant: 2),
+            title.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -8),
             title.topAnchor.constraint(equalTo: cell.topAnchor, constant: 8),
 
             metaField.leadingAnchor.constraint(equalTo: title.leadingAnchor),
-            metaField.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -12),
+            metaField.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -8),
             metaField.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 2),
 
             bottomView.bottomAnchor.constraint(equalTo: cell.bottomAnchor, constant: -8),
-
-            spinner.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -12),
-            spinner.topAnchor.constraint(equalTo: cell.topAnchor, constant: 8),
-            spinner.widthAnchor.constraint(equalToConstant: 16),
-            spinner.heightAnchor.constraint(equalToConstant: 16),
         ])
 
         if let summaryField {
             NSLayoutConstraint.activate([
                 summaryField.leadingAnchor.constraint(equalTo: title.leadingAnchor),
-                summaryField.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -12),
+                summaryField.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -8),
                 summaryField.topAnchor.constraint(equalTo: metaField.bottomAnchor, constant: 2),
             ])
         }

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -113,13 +113,11 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
 
         let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("session"))
         column.title = ""
-        column.resizingMask = .autoresizingMask
         listTableView.addTableColumn(column)
-        listTableView.columnAutoresizingStyle = .lastColumnOnlyAutoresizingStyle
         listTableView.headerView = nil
         listTableView.dataSource = self
         listTableView.delegate = self
-        listTableView.usesAutomaticRowHeights = true
+        listTableView.rowHeight = 52
         listTableView.backgroundColor = .clear
         listTableView.selectionHighlightStyle = .regular
         listTableView.target = self
@@ -384,7 +382,7 @@ extension SessionExplorerWindowController: NSTableViewDataSource, NSTableViewDel
     private func makeSessionCell(session: ExplorerSessionInfo, row: Int) -> NSView {
         let cell = NSTableCellView()
 
-        // Star toggle
+        // Star toggle — fixed size, left-aligned
         let starBtn = NSButton(title: session.isBookmarked ? "\u{2605}" : "\u{2606}", target: self, action: #selector(starClicked(_:)))
         starBtn.bezelStyle = .inline
         starBtn.isBordered = false
@@ -393,73 +391,53 @@ extension SessionExplorerWindowController: NSTableViewDataSource, NSTableViewDel
             ? NSColor(red: 1.0, green: 0.8, blue: 0.2, alpha: 0.7)
             : NSColor.tertiaryLabelColor
         starBtn.tag = row
-        starBtn.translatesAutoresizingMaskIntoConstraints = false
-        cell.addSubview(starBtn)
+        starBtn.setContentHuggingPriority(.required, for: .horizontal)
+        starBtn.setContentCompressionResistancePriority(.required, for: .horizontal)
 
-        // Title
+        // Title — single line, truncates
         let title = NSTextField(labelWithString: session.savedName ?? session.firstUserMessage)
         title.font = .systemFont(ofSize: 13, weight: session.sessionId == selectedSessionId ? .semibold : .regular)
         title.textColor = .labelColor
         title.lineBreakMode = .byTruncatingTail
-        title.maximumNumberOfLines = 5
-        title.cell?.wraps = true
-        title.cell?.isScrollable = false
-        title.translatesAutoresizingMaskIntoConstraints = false
-        title.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        cell.addSubview(title)
 
-        // Timestamp + message count
+        // Timestamp
         let timeStr = relativeFormatter.localizedString(for: session.modificationDate, relativeTo: Date())
-        let metaText = timeStr
-        let metaField = NSTextField(labelWithString: metaText)
+        let metaField = NSTextField(labelWithString: timeStr)
         metaField.font = .systemFont(ofSize: 10)
         metaField.textColor = .tertiaryLabelColor
-        metaField.translatesAutoresizingMaskIntoConstraints = false
-        cell.addSubview(metaField)
 
-        // AI summary
-        let summaryField: NSTextField?
+        // Text stack (title + meta + optional summary)
+        var textViews: [NSView] = [title, metaField]
+
         if let summary = session.summary {
             let field = NSTextField(labelWithString: summary)
             field.font = .systemFont(ofSize: 11)
             field.textColor = .secondaryLabelColor
             field.lineBreakMode = .byTruncatingTail
-            field.maximumNumberOfLines = 5
-            field.cell?.wraps = true
-            field.cell?.isScrollable = false
-            field.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-            field.translatesAutoresizingMaskIntoConstraints = false
-            cell.addSubview(field)
-            summaryField = field
-        } else {
-            summaryField = nil
+            field.maximumNumberOfLines = 2
+            textViews.append(field)
         }
 
-        let bottomView: NSView = summaryField ?? metaField
+        let textStack = NSStackView(views: textViews)
+        textStack.orientation = .vertical
+        textStack.alignment = .leading
+        textStack.spacing = 2
+
+        // Horizontal: star + text stack
+        let hStack = NSStackView(views: [starBtn, textStack])
+        hStack.orientation = .horizontal
+        hStack.alignment = .top
+        hStack.spacing = 4
+        hStack.translatesAutoresizingMaskIntoConstraints = false
+        hStack.edgeInsets = NSEdgeInsets(top: 6, left: 4, bottom: 6, right: 8)
+        cell.addSubview(hStack)
 
         NSLayoutConstraint.activate([
-            starBtn.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 4),
-            starBtn.topAnchor.constraint(equalTo: cell.topAnchor, constant: 8),
-            starBtn.widthAnchor.constraint(equalToConstant: 20),
-
-            title.leadingAnchor.constraint(equalTo: starBtn.trailingAnchor, constant: 2),
-            title.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -8),
-            title.topAnchor.constraint(equalTo: cell.topAnchor, constant: 8),
-
-            metaField.leadingAnchor.constraint(equalTo: title.leadingAnchor),
-            metaField.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -8),
-            metaField.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 2),
-
-            bottomView.bottomAnchor.constraint(equalTo: cell.bottomAnchor, constant: -8),
+            hStack.topAnchor.constraint(equalTo: cell.topAnchor),
+            hStack.bottomAnchor.constraint(equalTo: cell.bottomAnchor),
+            hStack.leadingAnchor.constraint(equalTo: cell.leadingAnchor),
+            hStack.trailingAnchor.constraint(equalTo: cell.trailingAnchor),
         ])
-
-        if let summaryField {
-            NSLayoutConstraint.activate([
-                summaryField.leadingAnchor.constraint(equalTo: title.leadingAnchor),
-                summaryField.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -8),
-                summaryField.topAnchor.constraint(equalTo: metaField.bottomAnchor, constant: 2),
-            ])
-        }
 
         return cell
     }

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -251,12 +251,17 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
     }
 
     @objc private func starClicked(_ sender: NSButton) {
-        let sessionId = filteredSessions[sender.tag].sessionId
+        let row = sender.tag
+        guard row < filteredSessions.count else { return }
+        let sessionId = filteredSessions[row].sessionId
         let newState = BookmarkManager.shared.toggleBookmark(projectPath: projectPath, sessionId: sessionId)
         if let idx = allSessions.firstIndex(where: { $0.sessionId == sessionId }) {
             allSessions[idx].isBookmarked = newState
         }
-        applyFilter()
+        if let fIdx = filteredSessions.firstIndex(where: { $0.sessionId == sessionId }) {
+            filteredSessions[fIdx].isBookmarked = newState
+            listTableView.reloadData(forRowIndexes: IndexSet(integer: fIdx), columnIndexes: IndexSet(integer: 0))
+        }
     }
 
     // MARK: - Search

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -363,6 +363,9 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
 
         // Generate action summaries for each turn
         let actions = ContextMonitor.shared.parseActions(sessionId: sessionId, projectPath: projectPath)
+        if !actions.isEmpty {
+            timelineController?.showActionSummaryProgress()
+        }
         SummaryManager.shared.generateTurnSummaries(sessionId: sessionId, actions: actions) { [weak self] summaries in
             guard let self, self.selectedSessionId == sessionId else { return }
             self.timelineController?.updateActionSummaries(summaries)

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -378,18 +378,8 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
     }
 
     private func summarizeAll(sessionId: String, entries: [TimelineEntry], actions: [Int: [String]]) {
-        guard let session = allSessions.first(where: { $0.sessionId == sessionId }) else { return }
+        timelineController?.setSummarizing(true)
 
-        // Show spinners on uncached action turns
-        let cached = SummaryManager.shared.cachedTurnSummaries(forSessionId: sessionId)
-        let uncachedTurns = Set(entries.map { $0.index }.filter {
-            actions[$0] != nil && !actions[$0]!.isEmpty && cached[$0] == nil
-        })
-        if !uncachedTurns.isEmpty {
-            timelineController?.setGeneratingTurns(uncachedTurns)
-        }
-
-        // Single combined AI call for both session summary + action summaries
         SummaryManager.shared.generateCombinedSummaries(
             sessionId: sessionId,
             projectPath: projectPath,
@@ -406,7 +396,7 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
             }
 
             self.timelineController?.updateActionSummaries(actionSummaries)
-            self.timelineController?.hideSummarizeButton()
+            self.timelineController?.setSummarizing(false)
         }
     }
 

--- a/Sources/Session/SessionExplorerWindowController.swift
+++ b/Sources/Session/SessionExplorerWindowController.swift
@@ -343,9 +343,14 @@ class SessionExplorerWindowController: NSWindowController, NSSplitViewDelegate, 
             if let summary = sessionSummary,
                let idx = self.allSessions.firstIndex(where: { $0.sessionId == sessionId }) {
                 self.allSessions[idx].summary = summary
-                self.applyFilter()
+                // Update just this row in the left sidebar without resetting scroll
+                if let fIdx = self.filteredSessions.firstIndex(where: { $0.sessionId == sessionId }) {
+                    self.filteredSessions[fIdx].summary = summary
+                    self.listTableView.reloadData(forRowIndexes: IndexSet(integer: fIdx), columnIndexes: IndexSet(integer: 0))
+                }
             }
 
+            // Rebuild right pane with updated data
             self.selectSession(sessionId: sessionId, scrollToMessageIndex: nil)
         }
     }

--- a/Sources/Session/SummaryManager.swift
+++ b/Sources/Session/SummaryManager.swift
@@ -70,6 +70,68 @@ class SummaryManager {
         }
     }
 
+    /// Generates concise action summaries for each turn in a session.
+    /// `actions` maps turn index to a list of raw action descriptions (tool names + args).
+    /// Calls `completion` on the main thread with a dictionary of turn index → summary string.
+    func generateTurnSummaries(sessionId: String, actions: [Int: [String]], completion: @escaping ([Int: String]) -> Void) {
+        let key = "turns-\(sessionId)"
+        guard !inFlightSessionIds.contains(key) else { return }
+
+        // Check cache
+        if let cached = cachedTurnSummaries[sessionId] {
+            completion(cached)
+            return
+        }
+
+        let nonEmpty = actions.filter { !$0.value.isEmpty }
+        guard !nonEmpty.isEmpty else {
+            completion([:])
+            return
+        }
+
+        inFlightSessionIds.insert(key)
+
+        // Build a prompt that asks haiku to summarize each turn's actions
+        var turnDescriptions: [(Int, String)] = []
+        for turnIndex in nonEmpty.keys.sorted() {
+            let actionList = nonEmpty[turnIndex]!.joined(separator: ", ")
+            turnDescriptions.append((turnIndex, actionList))
+        }
+
+        var promptLines = ["For each numbered turn below, write a single short sentence (max 10 words) summarizing what was done. Output one line per turn in the format \"N: summary\". No other text.\n"]
+        for (idx, desc) in turnDescriptions {
+            promptLines.append("\(idx): \(desc)")
+        }
+        let prompt = promptLines.joined(separator: "\n")
+
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            let result = self?.runClaudePrint(prompt: prompt)
+
+            DispatchQueue.main.async {
+                self?.inFlightSessionIds.remove(key)
+
+                var summaries: [Int: String] = [:]
+                if let output = result {
+                    for line in output.components(separatedBy: "\n") {
+                        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                        guard let colonIdx = trimmed.firstIndex(of: ":") else { continue }
+                        let numStr = trimmed[trimmed.startIndex..<colonIdx].trimmingCharacters(in: .whitespacesAndNewlines)
+                        guard let turnIdx = Int(numStr) else { continue }
+                        let summary = trimmed[trimmed.index(after: colonIdx)...].trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !summary.isEmpty {
+                            summaries[turnIdx] = summary
+                        }
+                    }
+                }
+
+                self?.cachedTurnSummaries[sessionId] = summaries
+                completion(summaries)
+            }
+        }
+    }
+
+    private var cachedTurnSummaries: [String: [Int: String]] = [:]
+
     // MARK: - Private
 
     private func runClaudePrint(prompt: String) -> String? {

--- a/Sources/Session/SummaryManager.swift
+++ b/Sources/Session/SummaryManager.swift
@@ -70,41 +70,61 @@ class SummaryManager {
         }
     }
 
-    /// Generates a concise action summary for a single turn.
-    /// Calls `completion` on the main thread with the summary string (or nil on failure).
-    func generateSingleTurnSummary(sessionId: String, turnIndex: Int, actions: [String], completion: @escaping (String?) -> Void) {
-        let cacheKey = "\(sessionId)-\(turnIndex)"
+    /// Generates concise action summaries for all turns in one batch haiku call.
+    /// `actions` maps turn index to a list of raw action descriptions.
+    /// Calls `completion` on the main thread with a dictionary of turn index → summary.
+    func generateTurnSummaries(sessionId: String, actions: [Int: [String]], completion: @escaping ([Int: String]) -> Void) {
+        let key = "turns-\(sessionId)"
+        guard !inFlightSessionIds.contains(key) else { return }
 
         // Check cache
-        if let cached = cachedTurnSummaries[cacheKey] {
+        if let cached = cachedTurnSummaries[sessionId] {
             completion(cached)
             return
         }
 
-        guard !actions.isEmpty else {
-            completion(nil)
+        let nonEmpty = actions.filter { !$0.value.isEmpty }
+        guard !nonEmpty.isEmpty else {
+            completion([:])
             return
         }
 
-        let actionList = actions.joined(separator: ", ")
-        let prompt = "Summarize these Claude Code actions in one short sentence (max 10 words). Only output the summary, nothing else.\n\nActions: \(actionList)"
+        inFlightSessionIds.insert(key)
+
+        var promptLines = ["For each numbered turn below, write a single short sentence (max 10 words) summarizing what was done. Output one line per turn in the format \"N: summary\". No other text.\n"]
+        for turnIndex in nonEmpty.keys.sorted() {
+            let actionList = nonEmpty[turnIndex]!.joined(separator: ", ")
+            promptLines.append("\(turnIndex): \(actionList)")
+        }
+        let prompt = promptLines.joined(separator: "\n")
 
         DispatchQueue.global(qos: .utility).async { [weak self] in
             let result = self?.runClaudePrint(prompt: prompt)
 
             DispatchQueue.main.async {
-                let summary = result?.trimmingCharacters(in: .whitespacesAndNewlines)
-                if let summary, !summary.isEmpty {
-                    self?.cachedTurnSummaries[cacheKey] = summary
-                    completion(summary)
-                } else {
-                    completion(nil)
+                self?.inFlightSessionIds.remove(key)
+
+                var summaries: [Int: String] = [:]
+                if let output = result {
+                    for line in output.components(separatedBy: "\n") {
+                        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                        guard let colonIdx = trimmed.firstIndex(of: ":") else { continue }
+                        let numStr = trimmed[trimmed.startIndex..<colonIdx].trimmingCharacters(in: .whitespacesAndNewlines)
+                        guard let turnIdx = Int(numStr) else { continue }
+                        let summary = trimmed[trimmed.index(after: colonIdx)...].trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !summary.isEmpty {
+                            summaries[turnIdx] = summary
+                        }
+                    }
                 }
+
+                self?.cachedTurnSummaries[sessionId] = summaries
+                completion(summaries)
             }
         }
     }
 
-    private var cachedTurnSummaries: [String: String] = [:]
+    private var cachedTurnSummaries: [String: [Int: String]] = [:]
 
     // MARK: - Private
 

--- a/Sources/Session/SummaryManager.swift
+++ b/Sources/Session/SummaryManager.swift
@@ -96,7 +96,7 @@ class SummaryManager {
         guard let resolvedPath = claudePath else { return nil }
 
         process.executableURL = URL(fileURLWithPath: resolvedPath)
-        process.arguments = ["--print", "-p", prompt]
+        process.arguments = ["--print", "--model", "haiku", "-p", prompt]
 
         let stdout = Pipe()
         let stderr = Pipe()

--- a/Sources/Session/SummaryManager.swift
+++ b/Sources/Session/SummaryManager.swift
@@ -17,6 +17,7 @@ class SummaryManager {
     struct CachedSummary: Codable {
         let summary: String
         let generatedAt: Date
+        var turnCount: Int?
     }
 
     /// Returns a cached summary for the session, or nil if not yet generated.
@@ -25,17 +26,27 @@ class SummaryManager {
         return all[sessionId]?.summary
     }
 
+    /// Returns the cached turn count for a session summary, or 0 if unknown.
+    func cachedSummaryTurnCount(forSessionId sessionId: String) -> Int {
+        let all = loadAll()
+        return all[sessionId]?.turnCount ?? 0
+    }
+
     /// Returns true if a summary generation is currently in progress for this session.
     func isGenerating(sessionId: String) -> Bool {
         inFlightSessionIds.contains(sessionId)
     }
 
-    /// Generates a summary asynchronously. Calls `completion` on the main thread with the result.
-    /// Does nothing if a summary is already cached or generation is in flight.
-    func generateSummary(sessionId: String, projectPath: String, completion: @escaping (String?) -> Void) {
-        // Already cached?
-        if let existing = cachedSummary(forSessionId: sessionId) {
-            completion(existing)
+    /// Generates a session summary. If a cached summary exists but the session has more
+    /// turns than when it was generated, the summary is regenerated.
+    /// Calls `completion` on the main thread with the result.
+    func generateSummary(sessionId: String, projectPath: String, currentTurnCount: Int, completion: @escaping (String?) -> Void) {
+        let all = loadAll()
+        let cached = all[sessionId]
+
+        // Return cached if it covers all current turns
+        if let cached, (cached.turnCount ?? 0) >= currentTurnCount {
+            completion(cached.summary)
             return
         }
 
@@ -47,12 +58,12 @@ class SummaryManager {
         let entries = ContextMonitor.shared.parseTimeline(sessionId: sessionId, projectPath: projectPath)
         guard !entries.isEmpty else {
             inFlightSessionIds.remove(sessionId)
-            completion(nil)
+            completion(cached?.summary)
             return
         }
 
         let userMessages = entries.map { $0.message }.joined(separator: "\n---\n")
-        let prompt = "Summarize this Claude Code session in one concise sentence, focusing on what was accomplished. Only output the summary, nothing else.\n\nUser messages:\n\(userMessages)"
+        let prompt = "Summarize this Claude Code session in 1-2 concise sentences, focusing on what was accomplished. Only output the summary, nothing else.\n\nUser messages:\n\(userMessages)"
 
         DispatchQueue.global(qos: .utility).async { [weak self] in
             let result = self?.runClaudePrint(prompt: prompt)
@@ -61,10 +72,10 @@ class SummaryManager {
                 self?.inFlightSessionIds.remove(sessionId)
 
                 if let summary = result, !summary.isEmpty {
-                    self?.saveSummary(sessionId: sessionId, summary: summary)
+                    self?.saveSummary(sessionId: sessionId, summary: summary, turnCount: entries.count)
                     completion(summary)
                 } else {
-                    completion(nil)
+                    completion(cached?.summary)
                 }
             }
         }
@@ -244,9 +255,9 @@ class SummaryManager {
         return dict
     }
 
-    private func saveSummary(sessionId: String, summary: String) {
+    private func saveSummary(sessionId: String, summary: String, turnCount: Int) {
         var all = loadAll()
-        all[sessionId] = CachedSummary(summary: summary, generatedAt: Date())
+        all[sessionId] = CachedSummary(summary: summary, generatedAt: Date(), turnCount: turnCount)
         cache = all
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]

--- a/Sources/Session/SummaryManager.swift
+++ b/Sources/Session/SummaryManager.swift
@@ -164,9 +164,14 @@ class SummaryManager {
                     self?.saveSummary(sessionId: sessionId, summary: summary, turnCount: currentTurnCount)
                 }
 
-                // Merge and persist turn summaries
-                let mergedTurns = existingTurnSummaries.merging(newTurnSummaries) { _, new in new }
-                if !newTurnSummaries.isEmpty {
+                // Mark all requested turns as cached (empty string for ones haiku skipped)
+                // so they aren't re-requested on next open
+                var allRequestedTurns: [Int: String] = [:]
+                for turnIndex in needsTurnSummaries.keys {
+                    allRequestedTurns[turnIndex] = newTurnSummaries[turnIndex] ?? ""
+                }
+                let mergedTurns = existingTurnSummaries.merging(allRequestedTurns) { _, new in new }
+                if !needsTurnSummaries.isEmpty {
                     self?.saveTurnSummaries(sessionId: sessionId, summaries: mergedTurns)
                 }
 

--- a/Sources/Session/SummaryManager.swift
+++ b/Sources/Session/SummaryManager.swift
@@ -70,67 +70,41 @@ class SummaryManager {
         }
     }
 
-    /// Generates concise action summaries for each turn in a session.
-    /// `actions` maps turn index to a list of raw action descriptions (tool names + args).
-    /// Calls `completion` on the main thread with a dictionary of turn index → summary string.
-    func generateTurnSummaries(sessionId: String, actions: [Int: [String]], completion: @escaping ([Int: String]) -> Void) {
-        let key = "turns-\(sessionId)"
-        guard !inFlightSessionIds.contains(key) else { return }
+    /// Generates a concise action summary for a single turn.
+    /// Calls `completion` on the main thread with the summary string (or nil on failure).
+    func generateSingleTurnSummary(sessionId: String, turnIndex: Int, actions: [String], completion: @escaping (String?) -> Void) {
+        let cacheKey = "\(sessionId)-\(turnIndex)"
 
         // Check cache
-        if let cached = cachedTurnSummaries[sessionId] {
+        if let cached = cachedTurnSummaries[cacheKey] {
             completion(cached)
             return
         }
 
-        let nonEmpty = actions.filter { !$0.value.isEmpty }
-        guard !nonEmpty.isEmpty else {
-            completion([:])
+        guard !actions.isEmpty else {
+            completion(nil)
             return
         }
 
-        inFlightSessionIds.insert(key)
-
-        // Build a prompt that asks haiku to summarize each turn's actions
-        var turnDescriptions: [(Int, String)] = []
-        for turnIndex in nonEmpty.keys.sorted() {
-            let actionList = nonEmpty[turnIndex]!.joined(separator: ", ")
-            turnDescriptions.append((turnIndex, actionList))
-        }
-
-        var promptLines = ["For each numbered turn below, write a single short sentence (max 10 words) summarizing what was done. Output one line per turn in the format \"N: summary\". No other text.\n"]
-        for (idx, desc) in turnDescriptions {
-            promptLines.append("\(idx): \(desc)")
-        }
-        let prompt = promptLines.joined(separator: "\n")
+        let actionList = actions.joined(separator: ", ")
+        let prompt = "Summarize these Claude Code actions in one short sentence (max 10 words). Only output the summary, nothing else.\n\nActions: \(actionList)"
 
         DispatchQueue.global(qos: .utility).async { [weak self] in
             let result = self?.runClaudePrint(prompt: prompt)
 
             DispatchQueue.main.async {
-                self?.inFlightSessionIds.remove(key)
-
-                var summaries: [Int: String] = [:]
-                if let output = result {
-                    for line in output.components(separatedBy: "\n") {
-                        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-                        guard let colonIdx = trimmed.firstIndex(of: ":") else { continue }
-                        let numStr = trimmed[trimmed.startIndex..<colonIdx].trimmingCharacters(in: .whitespacesAndNewlines)
-                        guard let turnIdx = Int(numStr) else { continue }
-                        let summary = trimmed[trimmed.index(after: colonIdx)...].trimmingCharacters(in: .whitespacesAndNewlines)
-                        if !summary.isEmpty {
-                            summaries[turnIdx] = summary
-                        }
-                    }
+                let summary = result?.trimmingCharacters(in: .whitespacesAndNewlines)
+                if let summary, !summary.isEmpty {
+                    self?.cachedTurnSummaries[cacheKey] = summary
+                    completion(summary)
+                } else {
+                    completion(nil)
                 }
-
-                self?.cachedTurnSummaries[sessionId] = summaries
-                completion(summaries)
             }
         }
     }
 
-    private var cachedTurnSummaries: [String: [Int: String]] = [:]
+    private var cachedTurnSummaries: [String: String] = [:]
 
     // MARK: - Private
 

--- a/Sources/Session/SummaryManager.swift
+++ b/Sources/Session/SummaryManager.swift
@@ -81,6 +81,103 @@ class SummaryManager {
         }
     }
 
+    // MARK: - Combined Summary (session + actions in one AI call)
+
+    /// Generates both a session summary and per-turn action summaries in a single haiku call.
+    /// Calls `completion` on the main thread with (sessionSummary, actionSummaries).
+    func generateCombinedSummaries(
+        sessionId: String,
+        projectPath: String,
+        currentTurnCount: Int,
+        actions: [Int: [String]],
+        completion: @escaping (String?, [Int: String]) -> Void
+    ) {
+        let key = "combined-\(sessionId)"
+        guard !inFlightSessionIds.contains(key) else { return }
+        inFlightSessionIds.insert(key)
+
+        // Determine what needs generation
+        let cachedSessionSummary = loadAll()[sessionId]
+        let needsSessionSummary = cachedSessionSummary == nil || (cachedSessionSummary?.turnCount ?? 0) < currentTurnCount
+
+        let existingTurnSummaries = cachedTurnSummaries(forSessionId: sessionId)
+        let nonEmpty = actions.filter { !$0.value.isEmpty }
+        let needsTurnSummaries = nonEmpty.filter { existingTurnSummaries[$0.key] == nil }
+
+        // If nothing to do, return cached
+        if !needsSessionSummary && needsTurnSummaries.isEmpty {
+            inFlightSessionIds.remove(key)
+            completion(cachedSessionSummary?.summary, existingTurnSummaries)
+            return
+        }
+
+        // Build combined prompt
+        let entries = ContextMonitor.shared.parseTimeline(sessionId: sessionId, projectPath: projectPath)
+        let userMessages = entries.map { $0.message }.joined(separator: "\n---\n")
+
+        var promptParts: [String] = []
+
+        if needsSessionSummary {
+            promptParts.append("PART 1: Summarize this Claude Code session in 1-2 concise sentences, focusing on what was accomplished. Output on a line starting with \"SESSION:\".")
+            promptParts.append("\nUser messages:\n\(userMessages)\n")
+        }
+
+        if !needsTurnSummaries.isEmpty {
+            promptParts.append("PART 2: For each numbered turn below, write a single short sentence (max 10 words) summarizing what was done. Output one line per turn in the format \"N: summary\".\n")
+            for turnIndex in needsTurnSummaries.keys.sorted() {
+                let actionList = needsTurnSummaries[turnIndex]!.joined(separator: ", ")
+                promptParts.append("\(turnIndex): \(actionList)")
+            }
+        }
+
+        promptParts.append("\nOutput nothing else.")
+        let prompt = promptParts.joined(separator: "\n")
+
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            let result = self?.runClaudePrint(prompt: prompt)
+
+            DispatchQueue.main.async {
+                self?.inFlightSessionIds.remove(key)
+
+                var sessionSummary: String?
+                var newTurnSummaries: [Int: String] = [:]
+
+                if let output = result {
+                    for line in output.components(separatedBy: "\n") {
+                        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if trimmed.hasPrefix("SESSION:") {
+                            sessionSummary = String(trimmed.dropFirst("SESSION:".count)).trimmingCharacters(in: .whitespacesAndNewlines)
+                        } else if let colonIdx = trimmed.firstIndex(of: ":") {
+                            let numStr = trimmed[trimmed.startIndex..<colonIdx].trimmingCharacters(in: .whitespacesAndNewlines)
+                            if let turnIdx = Int(numStr) {
+                                let summary = trimmed[trimmed.index(after: colonIdx)...].trimmingCharacters(in: .whitespacesAndNewlines)
+                                if !summary.isEmpty {
+                                    newTurnSummaries[turnIdx] = summary
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Persist session summary
+                if let summary = sessionSummary, needsSessionSummary {
+                    self?.saveSummary(sessionId: sessionId, summary: summary, turnCount: currentTurnCount)
+                }
+
+                // Merge and persist turn summaries
+                let mergedTurns = existingTurnSummaries.merging(newTurnSummaries) { _, new in new }
+                if !newTurnSummaries.isEmpty {
+                    self?.saveTurnSummaries(sessionId: sessionId, summaries: mergedTurns)
+                }
+
+                completion(
+                    sessionSummary ?? cachedSessionSummary?.summary,
+                    mergedTurns
+                )
+            }
+        }
+    }
+
     // MARK: - Turn Summaries (persisted, incremental)
 
     struct CachedTurnSummaries: Codable {

--- a/Sources/Session/SummaryManager.swift
+++ b/Sources/Session/SummaryManager.swift
@@ -324,7 +324,7 @@ class SummaryManager {
         guard let resolvedPath = claudePath else { return nil }
 
         process.executableURL = URL(fileURLWithPath: resolvedPath)
-        process.arguments = ["--print", "--model", "haiku", "-p", prompt]
+        process.arguments = ["--print", "--model", "haiku", "--effort", "low", "-p", prompt]
 
         let stdout = Pipe()
         let stderr = Pipe()

--- a/Sources/Session/SummaryManager.swift
+++ b/Sources/Session/SummaryManager.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+/// Generates and caches AI-generated session summaries by shelling out to `claude --print`.
+class SummaryManager {
+    static let shared = SummaryManager()
+
+    private let fileURL: URL = {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let deckardDir = appSupport.appendingPathComponent("Deckard")
+        try? FileManager.default.createDirectory(at: deckardDir, withIntermediateDirectories: true)
+        return deckardDir.appendingPathComponent("session-summaries.json")
+    }()
+
+    private var cache: [String: CachedSummary]?
+    private var inFlightSessionIds = Set<String>()
+
+    struct CachedSummary: Codable {
+        let summary: String
+        let generatedAt: Date
+    }
+
+    /// Returns a cached summary for the session, or nil if not yet generated.
+    func cachedSummary(forSessionId sessionId: String) -> String? {
+        let all = loadAll()
+        return all[sessionId]?.summary
+    }
+
+    /// Returns true if a summary generation is currently in progress for this session.
+    func isGenerating(sessionId: String) -> Bool {
+        inFlightSessionIds.contains(sessionId)
+    }
+
+    /// Generates a summary asynchronously. Calls `completion` on the main thread with the result.
+    /// Does nothing if a summary is already cached or generation is in flight.
+    func generateSummary(sessionId: String, projectPath: String, completion: @escaping (String?) -> Void) {
+        // Already cached?
+        if let existing = cachedSummary(forSessionId: sessionId) {
+            completion(existing)
+            return
+        }
+
+        // Already in flight?
+        guard !inFlightSessionIds.contains(sessionId) else { return }
+        inFlightSessionIds.insert(sessionId)
+
+        // Parse user messages for the prompt
+        let entries = ContextMonitor.shared.parseTimeline(sessionId: sessionId, projectPath: projectPath)
+        guard !entries.isEmpty else {
+            inFlightSessionIds.remove(sessionId)
+            completion(nil)
+            return
+        }
+
+        let userMessages = entries.map { $0.message }.joined(separator: "\n---\n")
+        let prompt = "Summarize this Claude Code session in one concise sentence, focusing on what was accomplished. Only output the summary, nothing else.\n\nUser messages:\n\(userMessages)"
+
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            let result = self?.runClaudePrint(prompt: prompt)
+
+            DispatchQueue.main.async {
+                self?.inFlightSessionIds.remove(sessionId)
+
+                if let summary = result, !summary.isEmpty {
+                    self?.saveSummary(sessionId: sessionId, summary: summary)
+                    completion(summary)
+                } else {
+                    completion(nil)
+                }
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func runClaudePrint(prompt: String) -> String? {
+        let process = Process()
+        // Search common locations for the claude binary
+        let candidates = ["/usr/local/bin/claude", "/opt/homebrew/bin/claude"]
+        var claudePath: String?
+        for path in candidates {
+            if FileManager.default.isExecutableFile(atPath: path) {
+                claudePath = path
+                break
+            }
+        }
+        // Fallback: search PATH
+        if claudePath == nil, let pathEnv = ProcessInfo.processInfo.environment["PATH"] {
+            for dir in pathEnv.split(separator: ":") {
+                let full = "\(dir)/claude"
+                if FileManager.default.isExecutableFile(atPath: full) {
+                    claudePath = full
+                    break
+                }
+            }
+        }
+        guard let resolvedPath = claudePath else { return nil }
+
+        process.executableURL = URL(fileURLWithPath: resolvedPath)
+        process.arguments = ["--print", "-p", prompt]
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return nil
+        }
+
+        guard process.terminationStatus == 0 else { return nil }
+        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func loadAll() -> [String: CachedSummary] {
+        if let cached = cache { return cached }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let data = try? Data(contentsOf: fileURL),
+              let dict = try? decoder.decode([String: CachedSummary].self, from: data) else {
+            cache = [:]
+            return [:]
+        }
+        cache = dict
+        return dict
+    }
+
+    private func saveSummary(sessionId: String, summary: String) {
+        var all = loadAll()
+        all[sessionId] = CachedSummary(summary: summary, generatedAt: Date())
+        cache = all
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        guard let data = try? encoder.encode(all) else { return }
+        try? data.write(to: fileURL, options: .atomic)
+    }
+}

--- a/Sources/Session/SummaryManager.swift
+++ b/Sources/Session/SummaryManager.swift
@@ -70,30 +70,66 @@ class SummaryManager {
         }
     }
 
-    /// Generates concise action summaries for all turns in one batch haiku call.
-    /// `actions` maps turn index to a list of raw action descriptions.
-    /// Calls `completion` on the main thread with a dictionary of turn index → summary.
+    // MARK: - Turn Summaries (persisted, incremental)
+
+    struct CachedTurnSummaries: Codable {
+        var summaries: [String: String]  // "turnIndex" → summary (String keys for Codable)
+    }
+
+    private let turnSummariesURL: URL = {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let deckardDir = appSupport.appendingPathComponent("Deckard")
+        try? FileManager.default.createDirectory(at: deckardDir, withIntermediateDirectories: true)
+        return deckardDir.appendingPathComponent("turn-summaries.json")
+    }()
+
+    private var turnSummariesCache: [String: CachedTurnSummaries]?
+
+    /// Returns all cached turn summaries for a session.
+    func cachedTurnSummaries(forSessionId sessionId: String) -> [Int: String] {
+        let all = loadAllTurnSummaries()
+        guard let cached = all[sessionId] else { return [:] }
+        var result: [Int: String] = [:]
+        for (key, value) in cached.summaries {
+            if let idx = Int(key) { result[idx] = value }
+        }
+        return result
+    }
+
+    /// Generates action summaries for turns that don't already have cached summaries.
+    /// Returns cached summaries immediately via `completion`, then generates missing ones
+    /// and calls `completion` again with the full set when done.
+    /// `actions` maps turn index to raw action descriptions. `totalTurnCount` is the current
+    /// number of turns in the session (used to detect continued sessions).
     func generateTurnSummaries(sessionId: String, actions: [Int: [String]], completion: @escaping ([Int: String]) -> Void) {
         let key = "turns-\(sessionId)"
-        guard !inFlightSessionIds.contains(key) else { return }
 
-        // Check cache
-        if let cached = cachedTurnSummaries[sessionId] {
-            completion(cached)
-            return
-        }
+        // Load existing cached summaries
+        let existing = cachedTurnSummaries(forSessionId: sessionId)
 
+        // Figure out which turns need summarization (have actions but no cached summary)
         let nonEmpty = actions.filter { !$0.value.isEmpty }
-        guard !nonEmpty.isEmpty else {
-            completion([:])
+        let needsSummary = nonEmpty.filter { existing[$0.key] == nil }
+
+        // If everything is cached, return immediately
+        if needsSummary.isEmpty {
+            completion(existing)
             return
         }
 
+        // Return what we have so far
+        if !existing.isEmpty {
+            completion(existing)
+        }
+
+        // Don't double-generate
+        guard !inFlightSessionIds.contains(key) else { return }
         inFlightSessionIds.insert(key)
 
+        // Build prompt only for new turns
         var promptLines = ["For each numbered turn below, write a single short sentence (max 10 words) summarizing what was done. Output one line per turn in the format \"N: summary\". No other text.\n"]
-        for turnIndex in nonEmpty.keys.sorted() {
-            let actionList = nonEmpty[turnIndex]!.joined(separator: ", ")
+        for turnIndex in needsSummary.keys.sorted() {
+            let actionList = needsSummary[turnIndex]!.joined(separator: ", ")
             promptLines.append("\(turnIndex): \(actionList)")
         }
         let prompt = promptLines.joined(separator: "\n")
@@ -104,7 +140,7 @@ class SummaryManager {
             DispatchQueue.main.async {
                 self?.inFlightSessionIds.remove(key)
 
-                var summaries: [Int: String] = [:]
+                var newSummaries: [Int: String] = [:]
                 if let output = result {
                     for line in output.components(separatedBy: "\n") {
                         let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -113,18 +149,41 @@ class SummaryManager {
                         guard let turnIdx = Int(numStr) else { continue }
                         let summary = trimmed[trimmed.index(after: colonIdx)...].trimmingCharacters(in: .whitespacesAndNewlines)
                         if !summary.isEmpty {
-                            summaries[turnIdx] = summary
+                            newSummaries[turnIdx] = summary
                         }
                     }
                 }
 
-                self?.cachedTurnSummaries[sessionId] = summaries
-                completion(summaries)
+                // Merge with existing and persist
+                let merged = existing.merging(newSummaries) { _, new in new }
+                self?.saveTurnSummaries(sessionId: sessionId, summaries: merged)
+                completion(merged)
             }
         }
     }
 
-    private var cachedTurnSummaries: [String: [Int: String]] = [:]
+    private func loadAllTurnSummaries() -> [String: CachedTurnSummaries] {
+        if let cached = turnSummariesCache { return cached }
+        guard let data = try? Data(contentsOf: turnSummariesURL),
+              let dict = try? JSONDecoder().decode([String: CachedTurnSummaries].self, from: data) else {
+            turnSummariesCache = [:]
+            return [:]
+        }
+        turnSummariesCache = dict
+        return dict
+    }
+
+    private func saveTurnSummaries(sessionId: String, summaries: [Int: String]) {
+        var all = loadAllTurnSummaries()
+        var codable: [String: String] = [:]
+        for (key, value) in summaries { codable[String(key)] = value }
+        all[sessionId] = CachedTurnSummaries(summaries: codable)
+        turnSummariesCache = all
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        guard let data = try? encoder.encode(all) else { return }
+        try? data.write(to: turnSummariesURL, options: .atomic)
+    }
 
     // MARK: - Private
 

--- a/Sources/Session/SummaryManager.swift
+++ b/Sources/Session/SummaryManager.swift
@@ -105,13 +105,14 @@ class SummaryManager {
 
         do {
             try process.run()
-            process.waitUntilExit()
         } catch {
             return nil
         }
 
-        guard process.terminationStatus == 0 else { return nil }
         let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else { return nil }
         return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 

--- a/Sources/Window/DeckardWindowController.swift
+++ b/Sources/Window/DeckardWindowController.swift
@@ -482,6 +482,12 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
         exploreSessionsMenuAction(fakeMenuItem)
     }
 
+    func moveCurrentProjectOutOfFolder() {
+        guard selectedProjectIndex >= 0, selectedProjectIndex < projects.count else { return }
+        let project = projects[selectedProjectIndex]
+        moveProjectOutOfFolder(projectId: project.id)
+    }
+
     func closeProject(at index: Int) {
         guard index >= 0, index < projects.count else { return }
         let project = projects[index]

--- a/Sources/Window/DeckardWindowController.swift
+++ b/Sources/Window/DeckardWindowController.swift
@@ -474,6 +474,14 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
         closeProject(at: selectedProjectIndex)
     }
 
+    func exploreCurrentProjectSessions() {
+        guard selectedProjectIndex >= 0, selectedProjectIndex < projects.count else { return }
+        let project = projects[selectedProjectIndex]
+        let fakeMenuItem = NSMenuItem()
+        fakeMenuItem.representedObject = project
+        exploreSessionsMenuAction(fakeMenuItem)
+    }
+
     func closeProject(at index: Int) {
         guard index >= 0, index < projects.count else { return }
         let project = projects[index]

--- a/Sources/Window/DeckardWindowController.swift
+++ b/Sources/Window/DeckardWindowController.swift
@@ -585,7 +585,7 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
 
     // MARK: - Tab Management (within a project)
 
-    func createTabInProject(_ project: ProjectItem, isClaude: Bool, name: String? = nil, sessionIdToResume: String? = nil, tmuxSessionToResume: String? = nil, extraArgs: String? = nil) {
+    func createTabInProject(_ project: ProjectItem, isClaude: Bool, name: String? = nil, sessionIdToResume: String? = nil, forkSession: Bool = false, tmuxSessionToResume: String? = nil, extraArgs: String? = nil) {
         let surface = TerminalSurface()
         let tabName: String
         if let name = name {
@@ -621,7 +621,8 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
                 let encoded = project.path.claudeProjectDirName
                 let jsonlPath = NSHomeDirectory() + "/.claude/projects/\(encoded)/\(sessionIdToResume).jsonl"
                 if FileManager.default.fileExists(atPath: jsonlPath) {
-                    claudeArgs = " --resume \(sessionIdToResume)\(extraArgsSuffix)"
+                    let forkFlag = forkSession ? " --fork-session" : ""
+                    claudeArgs = " --resume \(sessionIdToResume)\(forkFlag)\(extraArgsSuffix)"
                 } else {
                     tab.sessionId = nil
                 }

--- a/Sources/Window/SidebarController.swift
+++ b/Sources/Window/SidebarController.swift
@@ -662,7 +662,8 @@ extension DeckardWindowController {
         let expectedTitle = "Sessions — \(project.name)"
         for window in NSApp.windows {
             if window.title == expectedTitle,
-               let controller = objc_getAssociatedObject(window, "explorerController") as? SessionExplorerWindowController {
+               objc_getAssociatedObject(window, "explorerController") is SessionExplorerWindowController {
+                NSApp.activate(ignoringOtherApps: true)
                 window.makeKeyAndOrderFront(nil)
                 return
             }
@@ -683,6 +684,7 @@ extension DeckardWindowController {
             self.saveState()
         }
 
+        NSApp.activate(ignoringOtherApps: true)
         explorer.showWindow(nil)
         explorer.window?.makeKeyAndOrderFront(nil)
 

--- a/Sources/Window/SidebarController.swift
+++ b/Sources/Window/SidebarController.swift
@@ -588,47 +588,10 @@ extension DeckardWindowController {
     func buildProjectContextMenu(for project: ProjectItem) -> NSMenu {
         let menu = NSMenu()
 
-        let resumeItem = NSMenuItem(title: "Resume Session", action: nil, keyEquivalent: "")
-        let resumeSubmenu = NSMenu()
-
-        let sessions = ContextMonitor.shared.listSessions(forProjectPath: project.path)
-        let openSessionIds = Set(project.tabs.compactMap { $0.sessionId })
-        let resumable = sessions.filter { !openSessionIds.contains($0.sessionId) }
-
-        if resumable.isEmpty {
-            let emptyItem = NSMenuItem(title: "No sessions to resume", action: nil, keyEquivalent: "")
-            emptyItem.isEnabled = false
-            resumeSubmenu.addItem(emptyItem)
-        } else {
-            let savedNames = SessionManager.shared.loadSessionNames()
-            let formatter = RelativeDateTimeFormatter()
-            formatter.unitsStyle = .abbreviated
-
-            for session in resumable.prefix(50) {
-                let timeStr = formatter.localizedString(for: session.modificationDate, relativeTo: Date())
-                let savedName = savedNames[session.sessionId]
-
-                let title: String
-                if let name = savedName, !name.isEmpty {
-                    title = "\(timeStr) \u{2014} \(name)"
-                } else if !session.firstUserMessage.isEmpty {
-                    let msg = session.firstUserMessage.count > 60
-                        ? String(session.firstUserMessage.prefix(60)) + "\u{2026}"
-                        : session.firstUserMessage
-                    title = "\(timeStr) \u{2014} \(msg)"
-                } else {
-                    title = timeStr
-                }
-
-                let item = NSMenuItem(title: title, action: #selector(resumeSessionMenuAction(_:)), keyEquivalent: "")
-                item.target = self
-                item.representedObject = ResumeSessionInfo(project: project, sessionId: session.sessionId, tabName: savedName)
-                resumeSubmenu.addItem(item)
-            }
-        }
-
-        resumeItem.submenu = resumeSubmenu
-        menu.addItem(resumeItem)
+        let exploreItem = NSMenuItem(title: "Explore Sessions", action: #selector(exploreSessionsMenuAction(_:)), keyEquivalent: "")
+        exploreItem.target = self
+        exploreItem.representedObject = project
+        menu.addItem(exploreItem)
 
         menu.addItem(.separator())
 
@@ -715,6 +678,32 @@ extension DeckardWindowController {
             }
         }
         saveState()
+    }
+
+    @objc func exploreSessionsMenuAction(_ sender: NSMenuItem) {
+        guard let project = sender.representedObject as? ProjectItem else { return }
+
+        let explorer = SessionExplorerWindowController(
+            projectPath: project.path,
+            projectName: project.name
+        )
+        explorer.onSessionAction = { [weak self] sessionId, fork in
+            guard let self else { return }
+            self.createTabInProject(project, isClaude: true, sessionIdToResume: sessionId, forkSession: fork)
+            project.selectedTabIndex = project.tabs.count - 1
+            if let idx = self.projects.firstIndex(where: { $0 === project }) {
+                self.selectProject(at: idx)
+            }
+            self.rebuildTabBar()
+            self.saveState()
+        }
+
+        // Retain the controller via the window
+        explorer.showWindow(nil)
+        explorer.window?.makeKeyAndOrderFront(nil)
+
+        // Keep a strong reference so the window isn't deallocated
+        objc_setAssociatedObject(explorer.window!, "explorerController", explorer, .OBJC_ASSOCIATION_RETAIN)
     }
 
     // MARK: - Sidebar Selection

--- a/Sources/Window/SidebarController.swift
+++ b/Sources/Window/SidebarController.swift
@@ -662,9 +662,9 @@ extension DeckardWindowController {
             projectPath: project.path,
             projectName: project.name
         )
-        explorer.onSessionAction = { [weak self] sessionId, fork in
+        explorer.onSessionAction = { [weak self] sessionId, fork, tabName in
             guard let self else { return }
-            self.createTabInProject(project, isClaude: true, sessionIdToResume: sessionId, forkSession: fork)
+            self.createTabInProject(project, isClaude: true, name: tabName, sessionIdToResume: sessionId, forkSession: fork)
             project.selectedTabIndex = project.tabs.count - 1
             if let idx = self.projects.firstIndex(where: { $0 === project }) {
                 self.selectProject(at: idx)

--- a/Sources/Window/SidebarController.swift
+++ b/Sources/Window/SidebarController.swift
@@ -658,6 +658,16 @@ extension DeckardWindowController {
     @objc func exploreSessionsMenuAction(_ sender: NSMenuItem) {
         guard let project = sender.representedObject as? ProjectItem else { return }
 
+        // If an explorer window already exists for this project, bring it to front
+        let expectedTitle = "Sessions — \(project.name)"
+        for window in NSApp.windows {
+            if window.title == expectedTitle,
+               let controller = objc_getAssociatedObject(window, "explorerController") as? SessionExplorerWindowController {
+                window.makeKeyAndOrderFront(nil)
+                return
+            }
+        }
+
         let explorer = SessionExplorerWindowController(
             projectPath: project.path,
             projectName: project.name
@@ -673,7 +683,6 @@ extension DeckardWindowController {
             self.saveState()
         }
 
-        // Retain the controller via the window
         explorer.showWindow(nil)
         explorer.window?.makeKeyAndOrderFront(nil)
 

--- a/Sources/Window/SidebarController.swift
+++ b/Sources/Window/SidebarController.swift
@@ -673,6 +673,7 @@ extension DeckardWindowController {
             projectPath: project.path,
             projectName: project.name
         )
+        explorer.openSessionIds = Set(project.tabs.compactMap { $0.sessionId })
         explorer.onSessionAction = { [weak self] sessionId, fork, tabName in
             guard let self else { return }
             self.createTabInProject(project, isClaude: true, name: tabName, sessionIdToResume: sessionId, forkSession: fork)

--- a/Sources/Window/SidebarController.swift
+++ b/Sources/Window/SidebarController.swift
@@ -591,6 +591,7 @@ extension DeckardWindowController {
 
         if isInFolder {
             let moveOutItem = NSMenuItem(title: "Move Out of Folder", action: #selector(moveProjectOutOfFolderAction(_:)), keyEquivalent: "")
+            moveOutItem.setShortcut(for: .moveOutOfFolder)
             moveOutItem.target = self
             moveOutItem.representedObject = project
             menu.addItem(moveOutItem)
@@ -610,6 +611,7 @@ extension DeckardWindowController {
         menu.addItem(.separator())
 
         let newFolderItem = NSMenuItem(title: "New Folder", action: #selector(newFolderMenuAction), keyEquivalent: "")
+        newFolderItem.setShortcut(for: .newSidebarFolder)
         newFolderItem.target = self
         menu.addItem(newFolderItem)
 

--- a/Sources/Window/SidebarController.swift
+++ b/Sources/Window/SidebarController.swift
@@ -574,17 +574,6 @@ extension DeckardWindowController {
 
     // MARK: - Project Context Menu
 
-    class ResumeSessionInfo {
-        let project: ProjectItem
-        let sessionId: String
-        let tabName: String?
-        init(project: ProjectItem, sessionId: String, tabName: String?) {
-            self.project = project
-            self.sessionId = sessionId
-            self.tabName = tabName
-        }
-    }
-
     func buildProjectContextMenu(for project: ProjectItem) -> NSMenu {
         let menu = NSMenu()
 
@@ -659,25 +648,6 @@ extension DeckardWindowController {
         guard let project = sender.representedObject as? ProjectItem,
               let pi = projects.firstIndex(where: { $0.id == project.id }) else { return }
         closeProject(at: pi)
-    }
-
-    @objc func resumeSessionMenuAction(_ sender: NSMenuItem) {
-        guard let info = sender.representedObject as? ResumeSessionInfo else { return }
-        let project = info.project
-        let sessionId = info.sessionId
-
-        createTabInProject(project, isClaude: true, name: info.tabName, sessionIdToResume: sessionId)
-        project.selectedTabIndex = project.tabs.count - 1
-
-        if let pi = projects.firstIndex(where: { $0.id == project.id }) {
-            if pi == selectedProjectIndex {
-                rebuildTabBar()
-                showTab(project.tabs[project.selectedTabIndex])
-            } else {
-                selectProject(at: pi)
-            }
-        }
-        saveState()
     }
 
     @objc func exploreSessionsMenuAction(_ sender: NSMenuItem) {

--- a/Sources/Window/SidebarController.swift
+++ b/Sources/Window/SidebarController.swift
@@ -1,4 +1,5 @@
 import AppKit
+import KeyboardShortcuts
 
 // MARK: - Sidebar Controller Extension
 
@@ -578,6 +579,7 @@ extension DeckardWindowController {
         let menu = NSMenu()
 
         let exploreItem = NSMenuItem(title: "Explore Sessions", action: #selector(exploreSessionsMenuAction(_:)), keyEquivalent: "")
+        exploreItem.setShortcut(for: .exploreSessions)
         exploreItem.target = self
         exploreItem.representedObject = project
         menu.addItem(exploreItem)
@@ -614,6 +616,7 @@ extension DeckardWindowController {
         menu.addItem(.separator())
 
         let closeItem = NSMenuItem(title: "Close Folder", action: #selector(closeProjectMenuAction(_:)), keyEquivalent: "")
+        closeItem.setShortcut(for: .closeFolder)
         closeItem.target = self
         closeItem.representedObject = project
         menu.addItem(closeItem)

--- a/Tests/ContextMonitorTests.swift
+++ b/Tests/ContextMonitorTests.swift
@@ -143,7 +143,8 @@ final class ContextMonitorTests: XCTestCase {
         let info = ContextMonitor.SessionInfo(
             sessionId: "sess-123",
             modificationDate: date,
-            firstUserMessage: "Hello Claude"
+            firstUserMessage: "Hello Claude",
+            messageCount: 5
         )
 
         XCTAssertEqual(info.sessionId, "sess-123")


### PR DESCRIPTION
## Summary

- Replaces the right-click "Resume Session" dropdown on projects with a single "Explore Sessions" menu item that opens a dedicated session explorer window
- Two-column layout: left pane shows bookmarks + searchable session list, right pane shows conversation timeline with per-message fork and bookmark actions
- Adds `--fork-session` support to `createTabInProject` for branching conversations
- AI-generated session summaries via `claude --print` (on-demand, cached)
- Bookmark system lets users star specific points in conversations as reusable "save points"
- Mid-conversation forking creates a truncated JSONL copy and launches `claude --resume <id> --fork-session`

Closes #52

## Test plan

- [ ] Right-click a project → "Explore Sessions" menu item appears (no more "Resume Session" submenu)
- [ ] Clicking "Explore Sessions" opens the session explorer window with correct title
- [ ] Sessions listed in left pane sorted by most recent, with search filtering
- [ ] Selecting a session shows its timeline in the right pane
- [ ] "Resume" button creates a new tab and closes the explorer
- [ ] "Fork" button creates a new tab with `--fork-session` and closes the explorer
- [ ] "Fork here" on a timeline entry creates a truncated JSONL and opens a forked session
- [ ] Star toggle prompts for a label and adds a bookmark
- [ ] Bookmarks appear at the top of the left pane list with gold tint
- [ ] Clicking a bookmark selects its session and scrolls to the bookmarked message
- [ ] Summary generation shows spinner, then updates with AI summary
- [ ] Explorer window properly deallocates on close (no memory leak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)