### PR TITLE
fix: remove NSEvent monitor on ProjectPicker close

### DIFF
--- a/Sources/Window/ProjectPicker.swift
+++ b/Sources/Window/ProjectPicker.swift
@@ -3,7 +3,7 @@ import Fuse
 
 /// A Spotlight-style project picker that appears when creating a new Claude tab.
 /// Shows recent projects from ~/.claude/projects/, sorted by recency.
-class ProjectPicker: NSObject, NSTableViewDataSource, NSTableViewDelegate, NSTextFieldDelegate {
+class ProjectPicker: NSObject, NSTableViewDataSource, NSTableViewDelegate, NSTextFieldDelegate, NSWindowDelegate {
 
     typealias Completion = (String?) -> Void  // nil = cancelled, String = chosen path
 
@@ -62,6 +62,7 @@ class ProjectPicker: NSObject, NSTableViewDataSource, NSTableViewDelegate, NSTex
 
         super.init()
 
+        panel.delegate = self
         tableView.dataSource = self
         tableView.delegate = self
         tableView.target = self
@@ -216,6 +217,12 @@ class ProjectPicker: NSObject, NSTableViewDataSource, NSTableViewDelegate, NSTex
             NSEvent.removeMonitor(monitor)
             keyMonitor = nil
         }
+    }
+
+    // MARK: - NSWindowDelegate
+
+    func windowWillClose(_ notification: Notification) {
+        cancel()
     }
 
     /// Safely terminate the spotlight search, clearing the readability handler


### PR DESCRIPTION
## Summary

- **Fixes #56** — `NSEvent.addLocalMonitorForEvents` in `ProjectPicker.show()` was never removed, causing monitors to accumulate on every Cmd+O
- Added `private var keyMonitor: Any?` property to store the monitor token
- Monitor is now removed in `cancel()`, `confirm()`, and before re-adding in `show()`
- Follows the same pattern used by `DeckardWindowController.flagsMonitor`

## Test plan

- [ ] Open Deckard, press Cmd+O multiple times, close the picker each time — verify no duplicate key handling
- [ ] Confirm Enter, Escape, arrow keys, and Tab still work correctly in the picker
- [ ] Verify build succeeds with no warnings related to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)