### PR TITLE
feat: Claude CLI args autocomplete in settings

### DIFF
--- a/Deckard.xcodeproj/project.pbxproj
+++ b/Deckard.xcodeproj/project.pbxproj
@@ -64,6 +64,8 @@
 		SE000005SE000005SE000005 /* SummaryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE000006SE000006SE000006 /* SummaryManager.swift */; };
 		SE000007SE000007SE000007 /* SessionExplorerWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE000008SE000008SE000008 /* SessionExplorerWindowController.swift */; };
 		SE000009SE000009SE000009 /* SessionExplorerTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE00000ASE00000ASE00000A /* SessionExplorerTimelineView.swift */; };
+		CF000001CF000001CF000001 /* ClaudeCLIFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF000002CF000002CF000002 /* ClaudeCLIFlags.swift */; };
+		CF000003CF000003CF000003 /* ClaudeCLIFlagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF000004CF000004CF000004 /* ClaudeCLIFlagsTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -124,6 +126,8 @@
 		SE000006SE000006SE000006 /* SummaryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryManager.swift; sourceTree = "<group>"; };
 		SE000008SE000008SE000008 /* SessionExplorerWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionExplorerWindowController.swift; sourceTree = "<group>"; };
 		SE00000ASE00000ASE00000A /* SessionExplorerTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionExplorerTimelineView.swift; sourceTree = "<group>"; };
+		CF000002CF000002CF000002 /* ClaudeCLIFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeCLIFlags.swift; sourceTree = "<group>"; };
+		CF000004CF000004CF000004 /* ClaudeCLIFlagsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeCLIFlagsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -257,6 +261,7 @@
 				AABB0005AABB0005AABB0005 /* ShortcutNames.swift */,
 				AABB0007AABB0007AABB0007 /* DeckardHooksInstaller.swift */,
 				FDAC0002FDAC0002FDAC0002 /* FullDiskAccessChecker.swift */,
+				CF000002CF000002CF000002 /* ClaudeCLIFlags.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -283,6 +288,7 @@
 				AA110002AA110002AA110002 /* ThemeColorsTests.swift */,
 				AA140002AA140002AA140002 /* ThemeManagerTests.swift */,
 				AA1B0002AA1B0002AA1B0002 /* WindowControllerLogicTests.swift */,
+				CF000004CF000004CF000004 /* ClaudeCLIFlagsTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -441,6 +447,7 @@
 				SE000005SE000005SE000005 /* SummaryManager.swift in Sources */,
 				SE000007SE000007SE000007 /* SessionExplorerWindowController.swift in Sources */,
 				SE000009SE000009SE000009 /* SessionExplorerTimelineView.swift in Sources */,
+				CF000001CF000001CF000001 /* ClaudeCLIFlags.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -467,6 +474,7 @@
 				AA1F0001AA1F0001AA1F0001 /* SidebarFolderTests.swift in Sources */,
 				AA200001AA200001AA200001 /* SidebarFolderViewTests.swift in Sources */,
 				QA200006QA200006QA200006 /* QuotaMonitorTests.swift in Sources */,
+				CF000003CF000003CF000003 /* ClaudeCLIFlagsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Deckard.xcodeproj/project.pbxproj
+++ b/Deckard.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		SE000007SE000007SE000007 /* SessionExplorerWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE000008SE000008SE000008 /* SessionExplorerWindowController.swift */; };
 		SE000009SE000009SE000009 /* SessionExplorerTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = SE00000ASE00000ASE00000A /* SessionExplorerTimelineView.swift */; };
 		CF000001CF000001CF000001 /* ClaudeCLIFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF000002CF000002CF000002 /* ClaudeCLIFlags.swift */; };
+		CAF00001CAF00001CAF00001 /* ClaudeArgsField.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF00002CAF00002CAF00002 /* ClaudeArgsField.swift */; };
 		CF000003CF000003CF000003 /* ClaudeCLIFlagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF000004CF000004CF000004 /* ClaudeCLIFlagsTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -128,6 +129,7 @@
 		SE00000ASE00000ASE00000A /* SessionExplorerTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionExplorerTimelineView.swift; sourceTree = "<group>"; };
 		CF000002CF000002CF000002 /* ClaudeCLIFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeCLIFlags.swift; sourceTree = "<group>"; };
 		CF000004CF000004CF000004 /* ClaudeCLIFlagsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeCLIFlagsTests.swift; sourceTree = "<group>"; };
+		CAF00002CAF00002CAF00002 /* ClaudeArgsField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeArgsField.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -217,6 +219,7 @@
 				4BE07F0C0F9D62925EF195F7 /* ProjectPicker.swift */,
 				DD37F7C8CC5243DCF0A1346E /* SettingsWindow.swift */,
 				TC100002TC100002TC100002 /* ThemeCardView.swift */,
+				CAF00002CAF00002CAF00002 /* ClaudeArgsField.swift */,
 			);
 			path = Window;
 			sourceTree = "<group>";
@@ -448,6 +451,7 @@
 				SE000007SE000007SE000007 /* SessionExplorerWindowController.swift in Sources */,
 				SE000009SE000009SE000009 /* SessionExplorerTimelineView.swift in Sources */,
 				CF000001CF000001CF000001 /* ClaudeCLIFlags.swift in Sources */,
+				CAF00001CAF00001CAF00001 /* ClaudeArgsField.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -60,6 +60,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         log.log("startup", "Installing Claude Code hooks...")
         DeckardHooksInstaller.installIfNeeded()
 
+        // Parse Claude CLI flags for autocomplete in settings.
+        log.log("startup", "Loading Claude CLI flags...")
+        ClaudeCLIFlags.shared.load()
+
         // Clean up orphaned tmux sessions from previous runs
         if TerminalSurface.tmuxAvailable {
             let savedState = SessionManager.shared.load()

--- a/Sources/App/ClaudeCLIFlags.swift
+++ b/Sources/App/ClaudeCLIFlags.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+/// Represents a single CLI flag parsed from `claude --help`.
+struct ClaudeFlag {
+    let longName: String
+    let shortName: String?
+    let description: String
+    let valueType: ValueType
+    let valuePlaceholder: String?
+
+    enum ValueType: Equatable {
+        case boolean
+        case freeText
+        case enumeration([String])
+    }
+}
+
+/// Parses and caches CLI flags from `claude --help`.
+final class ClaudeCLIFlags {
+
+    static let shared = ClaudeCLIFlags()
+    private init() {}
+
+    /// Parsed flags. Empty until `load()` completes (or if claude is not installed).
+    private(set) var flags: [ClaudeFlag] = []
+
+    /// Flags Deckard manages internally — excluded from suggestions.
+    static let blocklist: Set<String> = [
+        "--resume", "--continue", "--fork-session", "--print", "--version", "--help",
+        "--output-format", "--input-format", "--include-partial-messages",
+        "--replay-user-messages", "--json-schema", "--max-budget-usd",
+        "--no-session-persistence", "--fallback-model", "--from-pr", "--session-id",
+    ]
+
+    /// Run `claude --help` asynchronously and parse the output.
+    func load() {
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            guard let output = Self.runClaudeHelp() else { return }
+            let parsed = Self.parse(helpOutput: output)
+            DispatchQueue.main.async {
+                self?.flags = parsed
+            }
+        }
+    }
+
+    /// Parse `claude --help` output into structured flags.
+    static func parse(helpOutput: String) -> [ClaudeFlag] {
+        // Matches lines like:
+        //   --flag <value>   Description
+        //   -s, --flag <value>   Description
+        //   --aliasA, --aliasB <value>   Description
+        // Groups: (1) short flag, (2) last long flag, (3) value placeholder, (4) description
+        let pattern = #"^\s+(?:(-\w),\s+)?(?:--[\w-]+,\s+)*(--[\w-]+)(?:\s+[\[<]([^\]>]+)[\]>](?:\.{3})?)?\s{2,}(.+)$"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: .anchorsMatchLines) else {
+            return []
+        }
+
+        var results: [ClaudeFlag] = []
+        let nsString = helpOutput as NSString
+
+        regex.enumerateMatches(in: helpOutput, range: NSRange(location: 0, length: nsString.length)) { match, _, _ in
+            guard let match else { return }
+
+            let shortName = match.range(at: 1).location != NSNotFound
+                ? nsString.substring(with: match.range(at: 1)) : nil
+            let longName = nsString.substring(with: match.range(at: 2))
+            let placeholder = match.range(at: 3).location != NSNotFound
+                ? nsString.substring(with: match.range(at: 3)) : nil
+            let desc = nsString.substring(with: match.range(at: 4))
+                .replacingOccurrences(of: "  +", with: " ", options: .regularExpression) // Collapse multi-space runs from column alignment
+
+            // Skip blocklisted flags
+            if blocklist.contains(longName) { return }
+
+            let valueType = Self.determineValueType(placeholder: placeholder, description: desc)
+
+            results.append(ClaudeFlag(
+                longName: longName,
+                shortName: shortName,
+                description: desc,
+                valueType: valueType,
+                valuePlaceholder: placeholder.map { "<\($0)>" }
+            ))
+        }
+
+        return results
+    }
+
+    private static func determineValueType(placeholder: String?, description: String) -> ClaudeFlag.ValueType {
+        guard placeholder != nil else { return .boolean }
+
+        // Explicit choices: (choices: "a", "b", "c")
+        if let choicesMatch = description.range(of: #"\(choices:\s*(.+?)\)"#, options: .regularExpression) {
+            let choicesStr = String(description[choicesMatch])
+            let quotedPattern = #""([^"]+)""#
+            if let quotedRegex = try? NSRegularExpression(pattern: quotedPattern) {
+                let nsStr = choicesStr as NSString
+                let matches = quotedRegex.matches(in: choicesStr, range: NSRange(location: 0, length: nsStr.length))
+                let values = matches.map { nsStr.substring(with: $0.range(at: 1)) }
+                if !values.isEmpty {
+                    return .enumeration(values)
+                }
+            }
+        }
+
+        // Informal enum: description ends with (word, word, word)
+        if let informalMatch = description.range(
+            of: #"\(([a-zA-Z][\w-]{0,19}(?:,\s*[a-zA-Z][\w-]{0,19}){1,7})\)\s*$"#,
+            options: .regularExpression
+        ) {
+            let inner = String(description[informalMatch].dropFirst().dropLast())
+                .trimmingCharacters(in: .whitespaces)
+            let items = inner.split(separator: ",").map { String($0).trimmingCharacters(in: .whitespaces) }
+            if items.count >= 2 && items.count <= 8 && items.allSatisfy({ !$0.contains(" ") && $0.count <= 20 }) {
+                return .enumeration(items)
+            }
+        }
+
+        return .freeText
+    }
+
+    private static func runClaudeHelp() -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["claude", "--help"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        do {
+            try process.run()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else { return nil }
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            return String(data: data, encoding: .utf8)
+        } catch {
+            return nil
+        }
+    }
+}

--- a/Sources/App/ClaudeCLIFlags.swift
+++ b/Sources/App/ClaudeCLIFlags.swift
@@ -32,6 +32,14 @@ final class ClaudeCLIFlags {
         "--no-session-persistence", "--fallback-model", "--from-pr", "--session-id",
     ]
 
+    /// Flags whose parsed valueType is overridden.
+    /// e.g. --worktree normally takes an optional [name], but we force it to boolean
+    /// so users can't pin a worktree name as a persistent default (which breaks sessions).
+    static let valueTypeOverrides: [String: ClaudeFlag.ValueType] = [
+        "--worktree": .boolean,
+        "--tmux": .boolean,
+    ]
+
     /// Posted on the main thread when flags finish loading.
     static let didLoadNotification = Notification.Name("ClaudeCLIFlagsDidLoad")
 
@@ -76,14 +84,15 @@ final class ClaudeCLIFlags {
             // Skip blocklisted flags
             if blocklist.contains(longName) { return }
 
-            let valueType = Self.determineValueType(placeholder: placeholder, description: desc)
+            let parsedType = Self.determineValueType(placeholder: placeholder, description: desc)
+            let valueType = valueTypeOverrides[longName] ?? parsedType
 
             results.append(ClaudeFlag(
                 longName: longName,
                 shortName: shortName,
                 description: desc,
                 valueType: valueType,
-                valuePlaceholder: placeholder.map { "<\($0)>" }
+                valuePlaceholder: valueType == .boolean ? nil : placeholder.map { "<\($0)>" }
             ))
         }
 

--- a/Sources/App/ClaudeCLIFlags.swift
+++ b/Sources/App/ClaudeCLIFlags.swift
@@ -137,3 +137,59 @@ final class ClaudeCLIFlags {
         }
     }
 }
+
+/// A single chip representing one CLI argument (flag + optional value).
+struct ArgsChip: Equatable {
+    let flag: String     // e.g. "--permission-mode"
+    let value: String?   // e.g. "auto", nil for boolean flags
+
+    /// Join chips into a CLI argument string.
+    static func serialize(_ chips: [ArgsChip]) -> String {
+        chips.map { chip in
+            if let value = chip.value {
+                return "\(chip.flag) \(value)"
+            }
+            return chip.flag
+        }.joined(separator: " ")
+    }
+
+    /// Parse a CLI argument string into chips, using known flags to determine
+    /// which flags take values. Unknown flags are assumed to take a value if
+    /// the next token doesn't start with "-".
+    static func deserialize(_ string: String, knownFlags: [ClaudeFlag]) -> [ArgsChip] {
+        let tokens = string.split(separator: " ", omittingEmptySubsequences: true).map(String.init)
+        guard !tokens.isEmpty else { return [] }
+
+        let flagMap = Dictionary(uniqueKeysWithValues: knownFlags.map { ($0.longName, $0) })
+        var chips: [ArgsChip] = []
+        var i = 0
+
+        while i < tokens.count {
+            let token = tokens[i]
+            guard token.hasPrefix("-") else {
+                i += 1
+                continue
+            }
+
+            if let known = flagMap[token] {
+                switch known.valueType {
+                case .boolean:
+                    chips.append(ArgsChip(flag: token, value: nil))
+                    i += 1
+                case .freeText, .enumeration:
+                    let value = (i + 1 < tokens.count && !tokens[i + 1].hasPrefix("-"))
+                        ? tokens[i + 1] : nil
+                    chips.append(ArgsChip(flag: token, value: value))
+                    i += (value != nil ? 2 : 1)
+                }
+            } else {
+                let value = (i + 1 < tokens.count && !tokens[i + 1].hasPrefix("-"))
+                    ? tokens[i + 1] : nil
+                chips.append(ArgsChip(flag: token, value: value))
+                i += (value != nil ? 2 : 1)
+            }
+        }
+
+        return chips
+    }
+}

--- a/Sources/App/ClaudeCLIFlags.swift
+++ b/Sources/App/ClaudeCLIFlags.swift
@@ -32,6 +32,9 @@ final class ClaudeCLIFlags {
         "--no-session-persistence", "--fallback-model", "--from-pr", "--session-id",
     ]
 
+    /// Posted on the main thread when flags finish loading.
+    static let didLoadNotification = Notification.Name("ClaudeCLIFlagsDidLoad")
+
     /// Run `claude --help` asynchronously and parse the output.
     func load() {
         DispatchQueue.global(qos: .utility).async { [weak self] in
@@ -39,6 +42,7 @@ final class ClaudeCLIFlags {
             let parsed = Self.parse(helpOutput: output)
             DispatchQueue.main.async {
                 self?.flags = parsed
+                NotificationCenter.default.post(name: Self.didLoadNotification, object: nil)
             }
         }
     }
@@ -120,9 +124,13 @@ final class ClaudeCLIFlags {
     }
 
     private static func runClaudeHelp() -> String? {
+        // Use a login shell so the user's full PATH is available.
+        // macOS apps launched from Finder get a minimal PATH that won't include
+        // homebrew, npm global, or other common install locations.
+        let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        process.arguments = ["claude", "--help"]
+        process.executableURL = URL(fileURLWithPath: shell)
+        process.arguments = ["-l", "-c", "claude --help"]
         let pipe = Pipe()
         process.standardOutput = pipe
         process.standardError = Pipe()

--- a/Sources/Window/ClaudeArgsField.swift
+++ b/Sources/Window/ClaudeArgsField.swift
@@ -255,9 +255,11 @@ extension ClaudeArgsField: NSTextFieldDelegate, NSTableViewDataSource, NSTableVi
 
         let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("Flag"))
         column.title = ""
+        column.resizingMask = .autoresizingMask
 
         let table = NSTableView()
         table.addTableColumn(column)
+        table.columnAutoresizingStyle = .lastColumnOnlyAutoresizingStyle
         table.headerView = nil
         table.rowHeight = 36
         table.selectionHighlightStyle = .regular
@@ -481,6 +483,14 @@ extension ClaudeArgsField: NSTextFieldDelegate, NSTableViewDataSource, NSTableVi
             return false
         }
 
+        if commandSelector == #selector(NSResponder.deleteForward(_:)) {
+            if textField.stringValue.isEmpty, let idx = selectedChipIndex {
+                removeChip(at: idx)
+                return true
+            }
+            return false
+        }
+
         if commandSelector == #selector(NSResponder.deleteBackward(_:)) {
             if textField.stringValue.isEmpty {
                 if let idx = selectedChipIndex {
@@ -598,6 +608,11 @@ extension ClaudeArgsField: NSTextFieldDelegate, NSTableViewDataSource, NSTableVi
         )
         suggestionWindow.setFrame(winFrame, display: true)
 
+        // Resize the table column to fill the window width.
+        if let table = suggestionTable, let col = table.tableColumns.first {
+            col.width = width
+        }
+
         if suggestionWindow.parent != parentWindow {
             parentWindow.addChildWindow(suggestionWindow, ordered: .above)
         }
@@ -632,33 +647,30 @@ extension ClaudeArgsField: NSTextFieldDelegate, NSTableViewDataSource, NSTableVi
             cell = NSTableCellView()
             cell.identifier = cellID
 
-            let stack = NSStackView()
-            stack.orientation = .vertical
-            stack.alignment = .leading
-            stack.spacing = 1
-            stack.translatesAutoresizingMaskIntoConstraints = false
-            stack.edgeInsets = NSEdgeInsets(top: 4, left: 8, bottom: 4, right: 8)
-
             let titleField = NSTextField(labelWithString: "")
             titleField.font = .monospacedSystemFont(ofSize: 12, weight: .bold)
             titleField.tag = 100
             titleField.lineBreakMode = .byTruncatingTail
+            titleField.translatesAutoresizingMaskIntoConstraints = false
+            titleField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
             let descField = NSTextField(labelWithString: "")
             descField.font = .systemFont(ofSize: 10)
             descField.textColor = .secondaryLabelColor
             descField.tag = 200
             descField.lineBreakMode = .byTruncatingTail
+            descField.translatesAutoresizingMaskIntoConstraints = false
+            descField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
-            stack.addArrangedSubview(titleField)
-            stack.addArrangedSubview(descField)
-
-            cell.addSubview(stack)
+            cell.addSubview(titleField)
+            cell.addSubview(descField)
             NSLayoutConstraint.activate([
-                stack.topAnchor.constraint(equalTo: cell.topAnchor),
-                stack.bottomAnchor.constraint(equalTo: cell.bottomAnchor),
-                stack.leadingAnchor.constraint(equalTo: cell.leadingAnchor),
-                stack.trailingAnchor.constraint(equalTo: cell.trailingAnchor),
+                titleField.topAnchor.constraint(equalTo: cell.topAnchor, constant: 4),
+                titleField.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 8),
+                titleField.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -8),
+                descField.topAnchor.constraint(equalTo: titleField.bottomAnchor, constant: 1),
+                descField.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 8),
+                descField.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -8),
             ])
         }
 

--- a/Sources/Window/ClaudeArgsField.swift
+++ b/Sources/Window/ClaudeArgsField.swift
@@ -627,7 +627,7 @@ extension ClaudeArgsField: NSTextFieldDelegate, NSTableViewDataSource, NSTableVi
         let count = enumChoices.isEmpty ? filteredFlags.count : enumChoices.count
         let rowHeight: CGFloat = 36
         let maxVisible = 6
-        let height = min(CGFloat(count), CGFloat(maxVisible)) * rowHeight + 4
+        let height = min(CGFloat(count), CGFloat(maxVisible)) * rowHeight + 8
         let width = max(bounds.width, 280)
 
         let winFrame = NSRect(

--- a/Sources/Window/ClaudeArgsField.swift
+++ b/Sources/Window/ClaudeArgsField.swift
@@ -8,7 +8,6 @@ final class ClaudeArgsField: NSView {
     var onChange: ((String) -> Void)?
 
     private var chips: [ArgsChip] = []
-    private let chipContainer = NSView()
     private let textField = NSTextField()
     private var chipViews: [NSView] = []
     private var selectedChipIndex: Int?
@@ -37,10 +36,6 @@ final class ClaudeArgsField: NSView {
         layer?.borderWidth = 1
         updateBorderColor()
 
-        chipContainer.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(chipContainer)
-
-        textField.translatesAutoresizingMaskIntoConstraints = false
         textField.isBordered = false
         textField.drawsBackground = false
         textField.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
@@ -55,18 +50,6 @@ final class ClaudeArgsField: NSView {
             self, selector: #selector(flagsDidLoad),
             name: ClaudeCLIFlags.didLoadNotification, object: nil
         )
-
-        NSLayoutConstraint.activate([
-            chipContainer.topAnchor.constraint(equalTo: topAnchor, constant: 4),
-            chipContainer.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 6),
-            chipContainer.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -6),
-
-            textField.topAnchor.constraint(equalTo: chipContainer.bottomAnchor, constant: 2),
-            textField.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
-            textField.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
-            textField.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -4),
-            textField.heightAnchor.constraint(equalToConstant: 22),
-        ])
     }
 
     override func viewDidChangeEffectiveAppearance() {
@@ -86,6 +69,8 @@ final class ClaudeArgsField: NSView {
             loadChips(from: current)
         }
     }
+
+    override var isFlipped: Bool { true }
 
     deinit {
         NotificationCenter.default.removeObserver(self)
@@ -116,40 +101,69 @@ final class ClaudeArgsField: NSView {
         chipViews.forEach { $0.removeFromSuperview() }
         chipViews.removeAll()
 
-        chipContainerHeightConstraint?.isActive = false
-
-        guard !chips.isEmpty else {
-            let zeroHeight = chipContainer.heightAnchor.constraint(equalToConstant: 0)
-            zeroHeight.isActive = true
-            chipContainerHeightConstraint = zeroHeight
-            textField.placeholderString = "Type a flag name..."
-            return
+        let hasPending = pendingFlag != nil
+        textField.placeholderString = if chips.isEmpty && !hasPending {
+            "Type a flag name..."
+        } else if hasPending {
+            pendingFlag?.valuePlaceholder ?? "<value>"
+        } else {
+            ""
         }
 
-        textField.placeholderString = ""
-
-        var x: CGFloat = 0
-        var y: CGFloat = 0
+        let inset: CGFloat = 6
         let spacing: CGFloat = 4
-        let maxWidth = bounds.width - 12
+        let rowHeight: CGFloat = 20
+        let maxWidth = bounds.width - inset * 2
+        var x: CGFloat = 0
+        var row: Int = 0
+
+        func wrap() {
+            x = 0
+            row += 1
+        }
+
+        func yForRow() -> CGFloat {
+            inset + CGFloat(row) * (rowHeight + spacing)
+        }
 
         for (i, chip) in chips.enumerated() {
             let view = makeChipView(chip, index: i)
-            let size = view.fittingSize
-            if x + size.width > maxWidth && x > 0 {
-                x = 0
-                y += size.height + spacing
-            }
-            view.frame = NSRect(x: x, y: y, width: size.width, height: size.height)
-            chipContainer.addSubview(view)
+            let w = view.fittingSize.width
+            if x + w > maxWidth && x > 0 { wrap() }
+            view.frame = NSRect(x: inset + x, y: yForRow(), width: w, height: rowHeight)
+            addSubview(view)
             chipViews.append(view)
-            x += size.width + spacing
+            x += w + spacing
         }
 
-        let totalHeight = y + (chipViews.last?.frame.height ?? 0)
-        let heightConstraint = chipContainer.heightAnchor.constraint(equalToConstant: totalHeight)
-        heightConstraint.isActive = true
-        chipContainerHeightConstraint = heightConstraint
+        if let flag = pendingFlag {
+            let preview = makePendingChipView(flag)
+            let w = preview.fittingSize.width
+            if x + w > maxWidth && x > 0 { wrap() }
+            preview.frame = NSRect(x: inset + x, y: yForRow(), width: w, height: rowHeight)
+            addSubview(preview)
+            chipViews.append(preview)
+            x += w + spacing
+        }
+
+        // Place the text field inline on the same row.
+        // Nudge down 2pt to align baselines with NSButton inline bezel text.
+        let minTextWidth: CGFloat = 80
+        let remainingWidth = maxWidth - x
+        if remainingWidth < minTextWidth && x > 0 { wrap() }
+        let tfWidth = x > 0 ? remainingWidth : maxWidth
+        textField.frame = NSRect(x: inset + x, y: yForRow() + 3, width: tfWidth, height: rowHeight)
+
+        let totalHeight = yForRow() + rowHeight + inset
+        // Update the view's intrinsic height via a frame-based constraint
+        if let existing = chipContainerHeightConstraint {
+            existing.constant = totalHeight
+        } else {
+            let hc = heightAnchor.constraint(equalToConstant: totalHeight)
+            hc.priority = .defaultHigh
+            hc.isActive = true
+            chipContainerHeightConstraint = hc
+        }
     }
 
     private func makeChipView(_ chip: ArgsChip, index: Int) -> NSView {
@@ -173,6 +187,19 @@ final class ClaudeArgsField: NSView {
             button.contentTintColor = .white
         }
 
+        return button
+    }
+
+    /// A dimmed chip showing the flag name while the user types its value.
+    private func makePendingChipView(_ flag: ClaudeFlag) -> NSView {
+        let button = NSButton(title: flag.longName, target: nil, action: nil)
+        button.bezelStyle = .inline
+        button.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
+        button.isBordered = true
+        button.isEnabled = false
+        button.wantsLayer = true
+        button.layer?.cornerRadius = 4
+        button.alphaValue = 0.6
         return button
     }
 
@@ -268,6 +295,8 @@ extension ClaudeArgsField: NSTextFieldDelegate, NSTableViewDataSource, NSTableVi
         table.backgroundColor = .clear
         table.dataSource = self
         table.delegate = self
+        table.action = #selector(suggestionClicked(_:))
+        table.target = self
 
         let scroll = NSScrollView(frame: effect.bounds)
         scroll.autoresizingMask = [.width, .height]
@@ -472,7 +501,7 @@ extension ClaudeArgsField: NSTextFieldDelegate, NSTableViewDataSource, NSTableVi
             if pendingFlag != nil {
                 pendingFlag = nil
                 textField.stringValue = ""
-                textField.placeholderString = chips.isEmpty ? "Type a flag name..." : ""
+                rebuildChipViews()
                 hideSuggestions()
                 return true
             }
@@ -533,7 +562,7 @@ extension ClaudeArgsField: NSTextFieldDelegate, NSTableViewDataSource, NSTableVi
         case .freeText:
             pendingFlag = flag
             textField.stringValue = ""
-            textField.placeholderString = flag.valuePlaceholder ?? "<value>"
+            rebuildChipViews()
         }
     }
 
@@ -566,17 +595,18 @@ extension ClaudeArgsField: NSTextFieldDelegate, NSTableViewDataSource, NSTableVi
             value = text.isEmpty ? nil : text
         }
 
-        if let value {
-            addChip(ArgsChip(flag: flag.longName, value: value))
-        } else {
-            // No value provided — add flag without value
-            addChip(ArgsChip(flag: flag.longName, value: nil))
-        }
-
+        // Clear pending state before addChip — addChip triggers rebuildChipViews
+        // which would render a ghost pending chip if pendingFlag is still set.
         pendingFlag = nil
         enumChoices = []
         textField.stringValue = ""
         textField.placeholderString = ""
+
+        if let value {
+            addChip(ArgsChip(flag: flag.longName, value: value))
+        } else {
+            addChip(ArgsChip(flag: flag.longName, value: nil))
+        }
         hideSuggestions()
     }
 
@@ -703,6 +733,25 @@ extension ClaudeArgsField: NSTextFieldDelegate, NSTableViewDataSource, NSTableVi
         }
 
         return cell
+    }
+
+    @objc private func suggestionClicked(_ sender: Any?) {
+        guard let table = suggestionTable, table.clickedRow >= 0 else { return }
+        selectedSuggestionRow = table.clickedRow
+
+        if !enumChoices.isEmpty {
+            // Accepting an enum choice
+            guard let flag = pendingFlag, table.clickedRow < enumChoices.count else { return }
+            let value = enumChoices[table.clickedRow]
+            pendingFlag = nil
+            textField.stringValue = ""
+            textField.placeholderString = ""
+            enumChoices = []
+            addChip(ArgsChip(flag: flag.longName, value: value))
+            hideSuggestions()
+        } else if table.clickedRow < filteredFlags.count {
+            acceptSuggestion(filteredFlags[table.clickedRow])
+        }
     }
 
     func tableViewSelectionDidChange(_ notification: Notification) {

--- a/Sources/Window/ClaudeArgsField.swift
+++ b/Sources/Window/ClaudeArgsField.swift
@@ -1,0 +1,194 @@
+import AppKit
+
+/// A chip-based text field for entering Claude CLI arguments with autocomplete.
+final class ClaudeArgsField: NSView {
+
+    var onChange: ((String) -> Void)?
+
+    private var chips: [ArgsChip] = []
+    private let chipContainer = NSView()
+    private let textField = NSTextField()
+    private var chipViews: [NSView] = []
+    private var selectedChipIndex: Int?
+    var pendingFlag: ClaudeFlag?
+
+    var stringValue: String {
+        get { ArgsChip.serialize(chips) }
+        set { loadChips(from: newValue) }
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    private func setup() {
+        wantsLayer = true
+        layer?.cornerRadius = 6
+        layer?.borderWidth = 1
+        updateBorderColor()
+
+        chipContainer.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(chipContainer)
+
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        textField.isBordered = false
+        textField.drawsBackground = false
+        textField.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        textField.focusRingType = .none
+        textField.placeholderString = "Type a flag name..."
+        textField.delegate = self
+        textField.cell?.sendsActionOnEndEditing = false
+        addSubview(textField)
+
+        NSLayoutConstraint.activate([
+            chipContainer.topAnchor.constraint(equalTo: topAnchor, constant: 4),
+            chipContainer.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 6),
+            chipContainer.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -6),
+
+            textField.topAnchor.constraint(equalTo: chipContainer.bottomAnchor, constant: 2),
+            textField.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
+            textField.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
+            textField.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -4),
+            textField.heightAnchor.constraint(equalToConstant: 22),
+        ])
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateBorderColor()
+    }
+
+    private func updateBorderColor() {
+        layer?.borderColor = NSColor.separatorColor.cgColor
+        layer?.backgroundColor = NSColor.controlBackgroundColor.cgColor
+    }
+
+    // MARK: - Chip Management
+
+    private func loadChips(from string: String) {
+        chips = ArgsChip.deserialize(string, knownFlags: ClaudeCLIFlags.shared.flags)
+        rebuildChipViews()
+    }
+
+    func addChip(_ chip: ArgsChip) {
+        chips.append(chip)
+        rebuildChipViews()
+        onChange?(stringValue)
+    }
+
+    private func removeChip(at index: Int) {
+        guard index >= 0 && index < chips.count else { return }
+        chips.remove(at: index)
+        selectedChipIndex = nil
+        rebuildChipViews()
+        onChange?(stringValue)
+    }
+
+    private func rebuildChipViews() {
+        chipViews.forEach { $0.removeFromSuperview() }
+        chipViews.removeAll()
+
+        chipContainer.constraints.filter { $0.firstAttribute == .height }.forEach { $0.isActive = false }
+
+        guard !chips.isEmpty else {
+            chipContainer.heightAnchor.constraint(equalToConstant: 0).isActive = true
+            textField.placeholderString = "Type a flag name..."
+            return
+        }
+
+        textField.placeholderString = ""
+
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        let spacing: CGFloat = 4
+        let maxWidth = bounds.width - 12
+
+        for (i, chip) in chips.enumerated() {
+            let view = makeChipView(chip, index: i)
+            let size = view.fittingSize
+            if x + size.width > maxWidth && x > 0 {
+                x = 0
+                y += size.height + spacing
+            }
+            view.frame = NSRect(x: x, y: y, width: size.width, height: size.height)
+            chipContainer.addSubview(view)
+            chipViews.append(view)
+            x += size.width + spacing
+        }
+
+        let totalHeight = y + (chipViews.last?.frame.height ?? 0)
+        chipContainer.heightAnchor.constraint(equalToConstant: totalHeight).isActive = true
+    }
+
+    private func makeChipView(_ chip: ArgsChip, index: Int) -> NSView {
+        let label: String
+        if let value = chip.value {
+            label = "\(chip.flag) \(value)"
+        } else {
+            label = chip.flag
+        }
+
+        let button = NSButton(title: label, target: self, action: #selector(chipClicked(_:)))
+        button.tag = index
+        button.bezelStyle = .inline
+        button.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
+        button.isBordered = true
+        button.wantsLayer = true
+        button.layer?.cornerRadius = 4
+
+        if selectedChipIndex == index {
+            button.layer?.backgroundColor = NSColor.selectedContentBackgroundColor.cgColor
+            button.contentTintColor = .white
+        }
+
+        return button
+    }
+
+    @objc private func chipClicked(_ sender: NSButton) {
+        if selectedChipIndex == sender.tag {
+            selectedChipIndex = nil
+        } else {
+            selectedChipIndex = sender.tag
+        }
+        rebuildChipViews()
+        window?.makeFirstResponder(textField)
+    }
+
+    // MARK: - Keyboard Handling
+
+    override func keyDown(with event: NSEvent) {
+        if event.keyCode == 51 /* Backspace */ {
+            if let idx = selectedChipIndex {
+                removeChip(at: idx)
+                return
+            }
+            if textField.stringValue.isEmpty && !chips.isEmpty {
+                selectedChipIndex = chips.count - 1
+                rebuildChipViews()
+                return
+            }
+        }
+        if event.keyCode == 53 /* Escape */ {
+            selectedChipIndex = nil
+            rebuildChipViews()
+        }
+        super.keyDown(with: event)
+    }
+
+    // MARK: - Layout
+
+    override func layout() {
+        super.layout()
+        rebuildChipViews()
+    }
+}
+
+// MARK: - NSTextFieldDelegate
+
+extension ClaudeArgsField: NSTextFieldDelegate {}

--- a/Sources/Window/ClaudeArgsField.swift
+++ b/Sources/Window/ClaudeArgsField.swift
@@ -1,4 +1,6 @@
 import AppKit
+import Fuse
+import ObjectiveC
 
 /// A chip-based text field for entering Claude CLI arguments with autocomplete.
 final class ClaudeArgsField: NSView {
@@ -10,7 +12,9 @@ final class ClaudeArgsField: NSView {
     private let textField = NSTextField()
     private var chipViews: [NSView] = []
     private var selectedChipIndex: Int?
-    var pendingFlag: ClaudeFlag?
+    private var pendingFlag: ClaudeFlag?
+    private var chipContainerHeightConstraint: NSLayoutConstraint?
+    private var lastLayoutWidth: CGFloat = 0
 
     var stringValue: String {
         get { ArgsChip.serialize(chips) }
@@ -94,10 +98,12 @@ final class ClaudeArgsField: NSView {
         chipViews.forEach { $0.removeFromSuperview() }
         chipViews.removeAll()
 
-        chipContainer.constraints.filter { $0.firstAttribute == .height }.forEach { $0.isActive = false }
+        chipContainerHeightConstraint?.isActive = false
 
         guard !chips.isEmpty else {
-            chipContainer.heightAnchor.constraint(equalToConstant: 0).isActive = true
+            let zeroHeight = chipContainer.heightAnchor.constraint(equalToConstant: 0)
+            zeroHeight.isActive = true
+            chipContainerHeightConstraint = zeroHeight
             textField.placeholderString = "Type a flag name..."
             return
         }
@@ -123,7 +129,9 @@ final class ClaudeArgsField: NSView {
         }
 
         let totalHeight = y + (chipViews.last?.frame.height ?? 0)
-        chipContainer.heightAnchor.constraint(equalToConstant: totalHeight).isActive = true
+        let heightConstraint = chipContainer.heightAnchor.constraint(equalToConstant: totalHeight)
+        heightConstraint.isActive = true
+        chipContainerHeightConstraint = heightConstraint
     }
 
     private func makeChipView(_ chip: ArgsChip, index: Int) -> NSView {
@@ -160,35 +168,522 @@ final class ClaudeArgsField: NSView {
         window?.makeFirstResponder(textField)
     }
 
-    // MARK: - Keyboard Handling
-
-    override func keyDown(with event: NSEvent) {
-        if event.keyCode == 51 /* Backspace */ {
-            if let idx = selectedChipIndex {
-                removeChip(at: idx)
-                return
-            }
-            if textField.stringValue.isEmpty && !chips.isEmpty {
-                selectedChipIndex = chips.count - 1
-                rebuildChipViews()
-                return
-            }
-        }
-        if event.keyCode == 53 /* Escape */ {
-            selectedChipIndex = nil
-            rebuildChipViews()
-        }
-        super.keyDown(with: event)
-    }
-
     // MARK: - Layout
 
     override func layout() {
         super.layout()
-        rebuildChipViews()
+        if bounds.width != lastLayoutWidth {
+            lastLayoutWidth = bounds.width
+            rebuildChipViews()
+        }
+    }
+
+    override func viewWillMove(toWindow newWindow: NSWindow?) {
+        if newWindow == nil {
+            hideSuggestions()
+        }
+        super.viewWillMove(toWindow: newWindow)
     }
 }
 
-// MARK: - NSTextFieldDelegate
+// MARK: - Suggestion Dropdown
 
-extension ClaudeArgsField: NSTextFieldDelegate {}
+// Associated object keys for extension storage
+private enum AssociatedKeys {
+    static var suggestionWindowKey: UInt8 = 0
+    static var suggestionTableKey: UInt8 = 0
+    static var filteredFlagsKey: UInt8 = 0
+    static var selectedSuggestionRowKey: UInt8 = 0
+    static var enumChoicesKey: UInt8 = 0
+    static var fuseInstanceKey: UInt8 = 0
+}
+
+extension ClaudeArgsField: NSTextFieldDelegate, NSTableViewDataSource, NSTableViewDelegate {
+
+    // MARK: - Associated Object Accessors
+
+    private var fuse: Fuse {
+        if let existing = objc_getAssociatedObject(self, &AssociatedKeys.fuseInstanceKey) as? Fuse {
+            return existing
+        }
+        let instance = Fuse(threshold: 0.4)
+        objc_setAssociatedObject(self, &AssociatedKeys.fuseInstanceKey, instance, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        return instance
+    }
+
+    private var suggestionWindow: NSWindow {
+        if let existing = objc_getAssociatedObject(self, &AssociatedKeys.suggestionWindowKey) as? NSWindow {
+            return existing
+        }
+        let win = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        win.isOpaque = false
+        win.backgroundColor = .clear
+        win.hasShadow = true
+        win.level = .floating
+
+        let effect = NSVisualEffectView(frame: win.contentView!.bounds)
+        effect.autoresizingMask = [.width, .height]
+        effect.material = .popover
+        effect.state = .active
+        effect.wantsLayer = true
+        effect.layer?.cornerRadius = 6
+        effect.layer?.masksToBounds = true
+        win.contentView?.addSubview(effect)
+
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("Flag"))
+        column.title = ""
+
+        let table = NSTableView()
+        table.addTableColumn(column)
+        table.headerView = nil
+        table.rowHeight = 36
+        table.selectionHighlightStyle = .regular
+        table.allowsEmptySelection = false
+        table.intercellSpacing = NSSize(width: 0, height: 0)
+        table.backgroundColor = .clear
+        table.dataSource = self
+        table.delegate = self
+
+        let scroll = NSScrollView(frame: effect.bounds)
+        scroll.autoresizingMask = [.width, .height]
+        scroll.documentView = table
+        scroll.hasVerticalScroller = true
+        scroll.autohidesScrollers = true
+        scroll.drawsBackground = false
+        effect.addSubview(scroll)
+
+        objc_setAssociatedObject(self, &AssociatedKeys.suggestionWindowKey, win, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        objc_setAssociatedObject(self, &AssociatedKeys.suggestionTableKey, table, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        return win
+    }
+
+    private var suggestionTable: NSTableView? {
+        objc_getAssociatedObject(self, &AssociatedKeys.suggestionTableKey) as? NSTableView
+    }
+
+    private var filteredFlags: [ClaudeFlag] {
+        get {
+            (objc_getAssociatedObject(self, &AssociatedKeys.filteredFlagsKey) as? [ClaudeFlag]) ?? []
+        }
+        set {
+            objc_setAssociatedObject(self, &AssociatedKeys.filteredFlagsKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+
+    private var selectedSuggestionRow: Int {
+        get {
+            (objc_getAssociatedObject(self, &AssociatedKeys.selectedSuggestionRowKey) as? Int) ?? -1
+        }
+        set {
+            objc_setAssociatedObject(self, &AssociatedKeys.selectedSuggestionRowKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+
+    /// Enum choices being shown (when user selected an enumeration flag).
+    private var enumChoices: [String] {
+        get {
+            (objc_getAssociatedObject(self, &AssociatedKeys.enumChoicesKey) as? [String]) ?? []
+        }
+        set {
+            objc_setAssociatedObject(self, &AssociatedKeys.enumChoicesKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+
+    // MARK: - NSTextFieldDelegate
+
+    func controlTextDidChange(_ obj: Notification) {
+        // Clear chip selection when typing
+        if selectedChipIndex != nil {
+            selectedChipIndex = nil
+            rebuildChipViews()
+        }
+
+        let text = textField.stringValue
+
+        // If we have a pending flag, don't show flag suggestions
+        if let flag = pendingFlag {
+            if case .enumeration(let values) = flag.valueType {
+                // Filter enum choices by typed text
+                if text.isEmpty {
+                    showEnumChoices(values, for: flag)
+                } else {
+                    let filtered = values.filter {
+                        $0.localizedCaseInsensitiveContains(text)
+                    }
+                    if filtered.isEmpty {
+                        hideSuggestions()
+                    } else {
+                        enumChoices = filtered
+                        filteredFlags = [] // Not showing flags
+                        suggestionTable?.reloadData()
+                        selectedSuggestionRow = 0
+                        suggestionTable?.selectRowIndexes(IndexSet(integer: 0), byExtendingSelection: false)
+                        showSuggestions()
+                    }
+                }
+            } else {
+                hideSuggestions()
+            }
+            return
+        }
+
+        guard !text.isEmpty else {
+            hideSuggestions()
+            return
+        }
+
+        // Strip leading dashes for matching
+        let query = text.replacingOccurrences(of: #"^-{0,2}"#, with: "", options: .regularExpression)
+        guard !query.isEmpty else {
+            // Show all flags if user just typed "--"
+            let allFlags = ClaudeCLIFlags.shared.flags.filter { flag in
+                !chips.contains(where: { $0.flag == flag.longName })
+            }
+            if allFlags.isEmpty {
+                hideSuggestions()
+            } else {
+                enumChoices = []
+                filteredFlags = allFlags
+                suggestionTable?.reloadData()
+                selectedSuggestionRow = 0
+                suggestionTable?.selectRowIndexes(IndexSet(integer: 0), byExtendingSelection: false)
+                showSuggestions()
+            }
+            return
+        }
+
+        // Fuzzy match against available flags
+        let addedFlagNames = Set(chips.map(\.flag))
+        var scored: [(flag: ClaudeFlag, score: Double)] = []
+
+        for flag in ClaudeCLIFlags.shared.flags {
+            // Skip already-added flags
+            if addedFlagNames.contains(flag.longName) { continue }
+
+            // Strip -- from flag name for matching
+            let flagName = flag.longName.replacingOccurrences(of: #"^--"#, with: "", options: .regularExpression)
+
+            // Try fuzzy match
+            let fuseResult = fuse.search(query, in: flagName)
+            let descResult = fuse.search(query, in: flag.description)
+
+            // Also try substring match as fallback
+            let substringMatch = flagName.localizedCaseInsensitiveContains(query)
+
+            if let score = [fuseResult?.score, descResult?.score].compactMap({ $0 }).min() {
+                scored.append((flag, score))
+            } else if substringMatch {
+                scored.append((flag, 0.5))
+            }
+        }
+
+        // Sort by score (lower is better)
+        scored.sort { $0.score < $1.score }
+
+        let results = scored.map(\.flag)
+
+        if results.isEmpty {
+            hideSuggestions()
+        } else {
+            enumChoices = []
+            filteredFlags = results
+            suggestionTable?.reloadData()
+            selectedSuggestionRow = 0
+            suggestionTable?.selectRowIndexes(IndexSet(integer: 0), byExtendingSelection: false)
+            showSuggestions()
+        }
+    }
+
+    func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+        let isVisible = suggestionWindow.isVisible
+
+        if commandSelector == #selector(NSResponder.moveUp(_:)) {
+            guard isVisible else { return false }
+            let count = enumChoices.isEmpty ? filteredFlags.count : enumChoices.count
+            guard count > 0 else { return false }
+            var row = selectedSuggestionRow - 1
+            if row < 0 { row = count - 1 }
+            selectedSuggestionRow = row
+            suggestionTable?.selectRowIndexes(IndexSet(integer: row), byExtendingSelection: false)
+            suggestionTable?.scrollRowToVisible(row)
+            return true
+        }
+
+        if commandSelector == #selector(NSResponder.moveDown(_:)) {
+            guard isVisible else { return false }
+            let count = enumChoices.isEmpty ? filteredFlags.count : enumChoices.count
+            guard count > 0 else { return false }
+            var row = selectedSuggestionRow + 1
+            if row >= count { row = 0 }
+            selectedSuggestionRow = row
+            suggestionTable?.selectRowIndexes(IndexSet(integer: row), byExtendingSelection: false)
+            suggestionTable?.scrollRowToVisible(row)
+            return true
+        }
+
+        if commandSelector == #selector(NSResponder.insertTab(_:)) ||
+            commandSelector == #selector(NSResponder.insertNewline(_:)) {
+            if pendingFlag != nil {
+                commitPendingFlag()
+                return true
+            }
+            if isVisible && !filteredFlags.isEmpty {
+                let row = max(0, selectedSuggestionRow)
+                if row < filteredFlags.count {
+                    acceptSuggestion(filteredFlags[row])
+                }
+                return true
+            }
+            // If text starts with "--" and no suggestions, accept as unknown flag
+            let text = textField.stringValue.trimmingCharacters(in: .whitespaces)
+            if text.hasPrefix("-") && !text.isEmpty {
+                acceptUnknownFlag(text)
+                return true
+            }
+            return false
+        }
+
+        if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
+            if pendingFlag != nil {
+                pendingFlag = nil
+                textField.stringValue = ""
+                textField.placeholderString = chips.isEmpty ? "Type a flag name..." : ""
+                hideSuggestions()
+                return true
+            }
+            if isVisible {
+                hideSuggestions()
+                return true
+            }
+            return false
+        }
+
+        if commandSelector == #selector(NSResponder.deleteBackward(_:)) {
+            if textField.stringValue.isEmpty {
+                if let idx = selectedChipIndex {
+                    removeChip(at: idx)
+                    return true
+                }
+                if pendingFlag != nil {
+                    pendingFlag = nil
+                    textField.placeholderString = chips.isEmpty ? "Type a flag name..." : ""
+                    hideSuggestions()
+                    return true
+                }
+                if !chips.isEmpty {
+                    selectedChipIndex = chips.count - 1
+                    rebuildChipViews()
+                    return true
+                }
+            }
+            return false
+        }
+
+        return false
+    }
+
+    // MARK: - Flag Acceptance
+
+    private func acceptSuggestion(_ flag: ClaudeFlag) {
+        hideSuggestions()
+        textField.stringValue = ""
+
+        switch flag.valueType {
+        case .boolean:
+            addChip(ArgsChip(flag: flag.longName, value: nil))
+
+        case .enumeration(let values):
+            pendingFlag = flag
+            textField.stringValue = ""
+            showEnumChoices(values, for: flag)
+
+        case .freeText:
+            pendingFlag = flag
+            textField.stringValue = ""
+            textField.placeholderString = flag.valuePlaceholder ?? "<value>"
+        }
+    }
+
+    private func showEnumChoices(_ values: [String], for flag: ClaudeFlag) {
+        enumChoices = values
+        filteredFlags = [] // Not showing flags
+        suggestionTable?.reloadData()
+        selectedSuggestionRow = 0
+        suggestionTable?.selectRowIndexes(IndexSet(integer: 0), byExtendingSelection: false)
+        showSuggestions()
+        textField.placeholderString = "Choose \(flag.longName) value..."
+    }
+
+    private func commitPendingFlag() {
+        guard let flag = pendingFlag else { return }
+
+        let value: String?
+
+        if !enumChoices.isEmpty {
+            // Use selected enum choice
+            let row = max(0, selectedSuggestionRow)
+            if row < enumChoices.count {
+                value = enumChoices[row]
+            } else {
+                value = enumChoices.first
+            }
+        } else {
+            // Use typed text for freeText
+            let text = textField.stringValue.trimmingCharacters(in: .whitespaces)
+            value = text.isEmpty ? nil : text
+        }
+
+        if let value {
+            addChip(ArgsChip(flag: flag.longName, value: value))
+        } else {
+            // No value provided — add flag without value
+            addChip(ArgsChip(flag: flag.longName, value: nil))
+        }
+
+        pendingFlag = nil
+        enumChoices = []
+        textField.stringValue = ""
+        textField.placeholderString = ""
+        hideSuggestions()
+    }
+
+    private func acceptUnknownFlag(_ text: String) {
+        hideSuggestions()
+        textField.stringValue = ""
+        addChip(ArgsChip(flag: text, value: nil))
+    }
+
+    // MARK: - Suggestion Window Positioning
+
+    private func showSuggestions() {
+        guard let parentWindow = window else { return }
+
+        let fieldRect = textField.convert(textField.bounds, to: nil)
+        let screenRect = parentWindow.convertToScreen(fieldRect)
+
+        let count = enumChoices.isEmpty ? filteredFlags.count : enumChoices.count
+        let rowHeight: CGFloat = 36
+        let maxVisible = 6
+        let height = min(CGFloat(count), CGFloat(maxVisible)) * rowHeight + 4
+        let width = max(bounds.width, 280)
+
+        let winFrame = NSRect(
+            x: screenRect.origin.x,
+            y: screenRect.origin.y - height - 2,
+            width: width,
+            height: height
+        )
+        suggestionWindow.setFrame(winFrame, display: true)
+
+        if suggestionWindow.parent != parentWindow {
+            parentWindow.addChildWindow(suggestionWindow, ordered: .above)
+        }
+        suggestionWindow.orderFront(nil)
+    }
+
+    private func hideSuggestions() {
+        guard let win = objc_getAssociatedObject(self, &AssociatedKeys.suggestionWindowKey) as? NSWindow else {
+            return
+        }
+        win.parent?.removeChildWindow(win)
+        win.orderOut(nil)
+    }
+
+    // MARK: - NSTableViewDataSource
+
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        if !enumChoices.isEmpty {
+            return enumChoices.count
+        }
+        return filteredFlags.count
+    }
+
+    // MARK: - NSTableViewDelegate
+
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        let cellID = NSUserInterfaceItemIdentifier("SuggestionCell")
+        let cell: NSTableCellView
+        if let reused = tableView.makeView(withIdentifier: cellID, owner: nil) as? NSTableCellView {
+            cell = reused
+        } else {
+            cell = NSTableCellView()
+            cell.identifier = cellID
+
+            let stack = NSStackView()
+            stack.orientation = .vertical
+            stack.alignment = .leading
+            stack.spacing = 1
+            stack.translatesAutoresizingMaskIntoConstraints = false
+            stack.edgeInsets = NSEdgeInsets(top: 4, left: 8, bottom: 4, right: 8)
+
+            let titleField = NSTextField(labelWithString: "")
+            titleField.font = .monospacedSystemFont(ofSize: 12, weight: .bold)
+            titleField.tag = 100
+            titleField.lineBreakMode = .byTruncatingTail
+
+            let descField = NSTextField(labelWithString: "")
+            descField.font = .systemFont(ofSize: 10)
+            descField.textColor = .secondaryLabelColor
+            descField.tag = 200
+            descField.lineBreakMode = .byTruncatingTail
+
+            stack.addArrangedSubview(titleField)
+            stack.addArrangedSubview(descField)
+
+            cell.addSubview(stack)
+            NSLayoutConstraint.activate([
+                stack.topAnchor.constraint(equalTo: cell.topAnchor),
+                stack.bottomAnchor.constraint(equalTo: cell.bottomAnchor),
+                stack.leadingAnchor.constraint(equalTo: cell.leadingAnchor),
+                stack.trailingAnchor.constraint(equalTo: cell.trailingAnchor),
+            ])
+        }
+
+        let titleField = cell.viewWithTag(100) as? NSTextField
+        let descField = cell.viewWithTag(200) as? NSTextField
+
+        if !enumChoices.isEmpty {
+            // Showing enum choices
+            guard row < enumChoices.count else { return cell }
+            let choice = enumChoices[row]
+            titleField?.stringValue = choice
+            titleField?.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+            descField?.stringValue = ""
+            descField?.isHidden = true
+        } else {
+            // Showing flag suggestions
+            guard row < filteredFlags.count else { return cell }
+            let flag = filteredFlags[row]
+            var title = flag.longName
+            if let short = flag.shortName {
+                title += " (\(short))"
+            }
+            if let placeholder = flag.valuePlaceholder {
+                title += " \(placeholder)"
+            }
+            titleField?.stringValue = title
+            titleField?.font = .monospacedSystemFont(ofSize: 12, weight: .bold)
+            descField?.stringValue = flag.description
+            descField?.isHidden = false
+        }
+
+        return cell
+    }
+
+    func tableViewSelectionDidChange(_ notification: Notification) {
+        guard let table = suggestionTable else { return }
+        let row = table.selectedRow
+        if row >= 0 {
+            selectedSuggestionRow = row
+        }
+    }
+
+    func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool {
+        true
+    }
+}

--- a/Sources/Window/ClaudeArgsField.swift
+++ b/Sources/Window/ClaudeArgsField.swift
@@ -50,6 +50,12 @@ final class ClaudeArgsField: NSView {
         textField.cell?.sendsActionOnEndEditing = false
         addSubview(textField)
 
+        // Re-parse chips when CLI flags finish loading (they load async at startup).
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(flagsDidLoad),
+            name: ClaudeCLIFlags.didLoadNotification, object: nil
+        )
+
         NSLayoutConstraint.activate([
             chipContainer.topAnchor.constraint(equalTo: topAnchor, constant: 4),
             chipContainer.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 6),
@@ -71,6 +77,18 @@ final class ClaudeArgsField: NSView {
     private func updateBorderColor() {
         layer?.borderColor = NSColor.separatorColor.cgColor
         layer?.backgroundColor = NSColor.controlBackgroundColor.cgColor
+    }
+
+    @objc private func flagsDidLoad() {
+        // Re-parse the current value now that we know which flags are boolean vs valued.
+        let current = stringValue
+        if !current.isEmpty {
+            loadChips(from: current)
+        }
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 
     // MARK: - Chip Management

--- a/Sources/Window/DeckardWindowController.swift
+++ b/Sources/Window/DeckardWindowController.swift
@@ -748,10 +748,8 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
         alert.addButton(withTitle: "Start")
         alert.addButton(withTitle: "Cancel")
 
-        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 300, height: 24))
-        field.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        let field = ClaudeArgsField(frame: NSRect(x: 0, y: 0, width: 400, height: 60))
         field.stringValue = UserDefaults.standard.string(forKey: "claudeExtraArgs") ?? ""
-        field.placeholderString = "--permission-mode auto"
         alert.accessoryView = field
 
         guard let window else {

--- a/Sources/Window/SettingsWindow.swift
+++ b/Sources/Window/SettingsWindow.swift
@@ -115,7 +115,8 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSTextFie
 
         let grid = NSGridView(numberOfColumns: 2, rows: 0)
         grid.translatesAutoresizingMaskIntoConstraints = false
-        grid.column(at: 0).xPlacement = .leading
+        grid.column(at: 0).xPlacement = .trailing
+        grid.column(at: 0).width = 120
         grid.column(at: 1).xPlacement = .fill
         grid.rowSpacing = 6
         grid.columnSpacing = 8

--- a/Sources/Window/SettingsWindow.swift
+++ b/Sources/Window/SettingsWindow.swift
@@ -124,14 +124,13 @@ class SettingsWindowController: NSWindowController, NSToolbarDelegate, NSTextFie
         let extraArgsLabel = NSTextField(labelWithString: "Extra arguments:")
         extraArgsLabel.alignment = .right
 
-        let extraArgsField = NSTextField()
+        let extraArgsField = ClaudeArgsField(frame: NSRect(x: 0, y: 0, width: 400, height: 60))
         extraArgsField.stringValue = UserDefaults.standard.string(forKey: "claudeExtraArgs") ?? ""
-        extraArgsField.placeholderString = "--permission-mode auto"
-        extraArgsField.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
-        objc_setAssociatedObject(extraArgsField, &settingsKeyAssoc, "claudeExtraArgs", .OBJC_ASSOCIATION_RETAIN)
-        extraArgsField.delegate = self
-        extraArgsField.target = self
-        extraArgsField.action = #selector(textFieldChanged(_:))
+        extraArgsField.translatesAutoresizingMaskIntoConstraints = false
+        extraArgsField.heightAnchor.constraint(greaterThanOrEqualToConstant: 36).isActive = true
+        extraArgsField.onChange = { newValue in
+            UserDefaults.standard.set(newValue, forKey: "claudeExtraArgs")
+        }
 
         grid.addRow(with: [extraArgsLabel, extraArgsField])
 

--- a/Tests/ClaudeCLIFlagsTests.swift
+++ b/Tests/ClaudeCLIFlagsTests.swift
@@ -86,3 +86,61 @@ final class ClaudeCLIFlagsTests: XCTestCase {
         XCTAssertTrue(flags.isEmpty)
     }
 }
+
+final class ArgsSerializationTests: XCTestCase {
+
+    func testSerializeChipsToString() {
+        let chips = [
+            ArgsChip(flag: "--permission-mode", value: "auto"),
+            ArgsChip(flag: "--verbose", value: nil),
+            ArgsChip(flag: "--model", value: "sonnet"),
+        ]
+        let result = ArgsChip.serialize(chips)
+        XCTAssertEqual(result, "--permission-mode auto --verbose --model sonnet")
+    }
+
+    func testDeserializeStringToChips() {
+        let input = "--permission-mode auto --verbose --model sonnet"
+        let flags = ClaudeCLIFlags.parse(helpOutput: """
+          --permission-mode <mode>   Permission mode (choices: "auto", "default")
+          --verbose                  Verbose
+          --model <model>            Model
+        """)
+        let chips = ArgsChip.deserialize(input, knownFlags: flags)
+        XCTAssertEqual(chips.count, 3)
+        XCTAssertEqual(chips[0].flag, "--permission-mode")
+        XCTAssertEqual(chips[0].value, "auto")
+        XCTAssertEqual(chips[1].flag, "--verbose")
+        XCTAssertNil(chips[1].value)
+        XCTAssertEqual(chips[2].flag, "--model")
+        XCTAssertEqual(chips[2].value, "sonnet")
+    }
+
+    func testDeserializeUnknownFlags() {
+        let input = "--unknown-flag some-value --verbose"
+        let flags = ClaudeCLIFlags.parse(helpOutput: """
+          --verbose   Verbose
+        """)
+        let chips = ArgsChip.deserialize(input, knownFlags: flags)
+        XCTAssertEqual(chips.count, 2)
+        XCTAssertEqual(chips[0].flag, "--unknown-flag")
+        XCTAssertEqual(chips[0].value, "some-value")
+        XCTAssertEqual(chips[1].flag, "--verbose")
+    }
+
+    func testRoundTrip() {
+        let original = "--permission-mode auto --verbose"
+        let flags = ClaudeCLIFlags.parse(helpOutput: """
+          --permission-mode <mode>   Permission mode (choices: "auto", "default")
+          --verbose                  Verbose
+        """)
+        let chips = ArgsChip.deserialize(original, knownFlags: flags)
+        let serialized = ArgsChip.serialize(chips)
+        XCTAssertEqual(serialized, original)
+    }
+
+    func testDeserializeEmptyString() {
+        let chips = ArgsChip.deserialize("", knownFlags: [])
+        XCTAssertTrue(chips.isEmpty)
+    }
+}

--- a/Tests/ClaudeCLIFlagsTests.swift
+++ b/Tests/ClaudeCLIFlagsTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import Deckard
+
+final class ClaudeCLIFlagsTests: XCTestCase {
+
+    // Sample help output (subset of real `claude --help`)
+    private let sampleHelp = """
+    Options:
+      --add-dir <directories...>                        Additional directories to allow tool access to
+      --verbose                                         Override verbose mode setting from config
+      --permission-mode <mode>                          Permission mode to use for the session (choices: "acceptEdits", "bypassPermissions", "default", "dontAsk", "plan", "auto")
+      --effort <level>                                  Effort level for the current session (low, medium, high, max)
+      --model <model>                                   Model for the current session. Provide an alias for the latest model (e.g. 'sonnet' or 'opus') or a model's full name (e.g. 'claude-sonnet-4-6').
+      -c, --continue                                    Continue the most recent conversation in the current directory
+      -d, --debug [filter]                              Enable debug mode with optional category filtering (e.g., "api,hooks" or "!1p,!file")
+      -p, --print                                       Print response and exit (useful for pipes).
+      --allowedTools, --allowed-tools <tools...>        Comma or space-separated list of tool names to allow (e.g. "Bash(git:*) Edit")
+      -v, --version                                     Output the version number
+      -h, --help                                        Display help for command
+      --resume [value]                                  Resume a conversation by session ID
+    """
+
+    func testParsesBooleanFlag() {
+        let flags = ClaudeCLIFlags.parse(helpOutput: sampleHelp)
+        let verbose = flags.first { $0.longName == "--verbose" }
+        XCTAssertNotNil(verbose)
+        XCTAssertEqual(verbose?.valueType, .boolean)
+        XCTAssertNil(verbose?.shortName)
+    }
+
+    func testParsesFlagWithShortName() {
+        let flags = ClaudeCLIFlags.parse(helpOutput: sampleHelp)
+        let debug = flags.first { $0.longName == "--debug" }
+        XCTAssertNotNil(debug)
+        XCTAssertEqual(debug?.shortName, "-d")
+    }
+
+    func testParsesExplicitChoices() {
+        let flags = ClaudeCLIFlags.parse(helpOutput: sampleHelp)
+        let permMode = flags.first { $0.longName == "--permission-mode" }
+        XCTAssertNotNil(permMode)
+        guard case .enumeration(let values) = permMode?.valueType else {
+            XCTFail("Expected enumeration"); return
+        }
+        XCTAssertEqual(values, ["acceptEdits", "bypassPermissions", "default", "dontAsk", "plan", "auto"])
+    }
+
+    func testParsesInformalEnum() {
+        let flags = ClaudeCLIFlags.parse(helpOutput: sampleHelp)
+        let effort = flags.first { $0.longName == "--effort" }
+        XCTAssertNotNil(effort)
+        guard case .enumeration(let values) = effort?.valueType else {
+            XCTFail("Expected enumeration"); return
+        }
+        XCTAssertEqual(values, ["low", "medium", "high", "max"])
+    }
+
+    func testParsesFreeTextValue() {
+        let flags = ClaudeCLIFlags.parse(helpOutput: sampleHelp)
+        let model = flags.first { $0.longName == "--model" }
+        XCTAssertNotNil(model)
+        XCTAssertEqual(model?.valueType, .freeText)
+        XCTAssertEqual(model?.valuePlaceholder, "<model>")
+    }
+
+    func testBlocklistExcludesInternalFlags() {
+        let flags = ClaudeCLIFlags.parse(helpOutput: sampleHelp)
+        let longNames = flags.map(\.longName)
+        XCTAssertFalse(longNames.contains("--continue"))
+        XCTAssertFalse(longNames.contains("--print"))
+        XCTAssertFalse(longNames.contains("--version"))
+        XCTAssertFalse(longNames.contains("--help"))
+        XCTAssertFalse(longNames.contains("--resume"))
+    }
+
+    func testParsesAliasedFlag() {
+        let flags = ClaudeCLIFlags.parse(helpOutput: sampleHelp)
+        // --allowedTools, --allowed-tools should produce one entry
+        let allowed = flags.first { $0.longName == "--allowed-tools" }
+        XCTAssertNotNil(allowed)
+        XCTAssertEqual(allowed?.valueType, .freeText)
+    }
+
+    func testEmptyInputReturnsEmptyArray() {
+        let flags = ClaudeCLIFlags.parse(helpOutput: "")
+        XCTAssertTrue(flags.isEmpty)
+    }
+}

--- a/Tests/ClaudeCLIFlagsTests.swift
+++ b/Tests/ClaudeCLIFlagsTests.swift
@@ -18,6 +18,8 @@ final class ClaudeCLIFlagsTests: XCTestCase {
       -v, --version                                     Output the version number
       -h, --help                                        Display help for command
       --resume [value]                                  Resume a conversation by session ID
+      -w, --worktree [name]                              Create a new git worktree for this session (optionally specify a name)
+      --tmux                                             Create a tmux session for the worktree (requires --worktree). Uses iTerm2 native panes when available; use --tmux=classic for traditional tmux.
     """
 
     func testParsesBooleanFlag() {
@@ -71,6 +73,15 @@ final class ClaudeCLIFlagsTests: XCTestCase {
         XCTAssertFalse(longNames.contains("--version"))
         XCTAssertFalse(longNames.contains("--help"))
         XCTAssertFalse(longNames.contains("--resume"))
+    }
+
+    func testValueTypeOverrideForcesBoolean() {
+        let flags = ClaudeCLIFlags.parse(helpOutput: sampleHelp)
+        let worktree = flags.first { $0.longName == "--worktree" }
+        XCTAssertNotNil(worktree)
+        XCTAssertEqual(worktree?.valueType, .boolean)
+        XCTAssertNil(worktree?.valuePlaceholder)
+        XCTAssertEqual(worktree?.shortName, "-w")
     }
 
     func testParsesAliasedFlag() {

--- a/docs/superpowers/plans/2026-03-31-claude-args-autocomplete.md
+++ b/docs/superpowers/plans/2026-03-31-claude-args-autocomplete.md
@@ -1,0 +1,1159 @@
+# Claude CLI Args Autocomplete — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the plain text field for Claude CLI start parameters with a chip-based autocomplete field powered by `claude --help`.
+
+**Architecture:** Two new files — `ClaudeCLIFlags.swift` (model + parser + singleton) and `ClaudeArgsField.swift` (custom NSView with chips, inline text field, and suggestion dropdown). Existing settings and per-session dialog swap in the new field. Fuse library (already a dependency) provides fuzzy matching.
+
+**Tech Stack:** Swift, AppKit (NSView, NSTextField, NSWindow, NSTableView), Fuse (fuzzy search), Process (CLI invocation), XCTest
+
+---
+
+### Task 1: ClaudeFlag Model & Help Parser
+
+**Files:**
+- Create: `Sources/App/ClaudeCLIFlags.swift`
+- Create: `Tests/ClaudeCLIFlagsTests.swift`
+
+- [ ] **Step 1: Write failing tests for help output parsing**
+
+Create `Tests/ClaudeCLIFlagsTests.swift`:
+
+```swift
+import XCTest
+@testable import Deckard
+
+final class ClaudeCLIFlagsTests: XCTestCase {
+
+    // Sample help output (subset of real `claude --help`)
+    private let sampleHelp = """
+    Options:
+      --add-dir <directories...>                        Additional directories to allow tool access to
+      --verbose                                         Override verbose mode setting from config
+      --permission-mode <mode>                          Permission mode to use for the session (choices: "acceptEdits", "bypassPermissions", "default", "dontAsk", "plan", "auto")
+      --effort <level>                                  Effort level for the current session (low, medium, high, max)
+      --model <model>                                   Model for the current session. Provide an alias for the latest model (e.g. 'sonnet' or 'opus') or a model's full name (e.g. 'claude-sonnet-4-6').
+      -c, --continue                                    Continue the most recent conversation in the current directory
+      -d, --debug [filter]                              Enable debug mode with optional category filtering (e.g., "api,hooks" or "!1p,!file")
+      -p, --print                                       Print response and exit (useful for pipes).
+      --allowedTools, --allowed-tools <tools...>        Comma or space-separated list of tool names to allow (e.g. "Bash(git:*) Edit")
+      -v, --version                                     Output the version number
+      -h, --help                                        Display help for command
+      --resume [value]                                  Resume a conversation by session ID
+    """
+
+    func testParsesBooleanFlag() {
+        let flags = ClaudeCLIFlags.parse(helpOutput: sampleHelp)
+        let verbose = flags.first { $0.longName == "--verbose" }
+        XCTAssertNotNil(verbose)
+        XCTAssertEqual(verbose?.valueType, .boolean)
+        XCTAssertNil(verbose?.shortName)
+    }
+
+    func testParsesFlagWithShortName() {
+        let flags = ClaudeCLIFlags.parse(helpOutput: sampleHelp)
+        let debug = flags.first { $0.longName == "--debug" }
+        XCTAssertNotNil(debug)
+        XCTAssertEqual(debug?.shortName, "-d")
+    }
+
+    func testParsesExplicitChoices() {
+        let flags = ClaudeCLIFlags.parse(helpOutput: sampleHelp)
+        let permMode = flags.first { $0.longName == "--permission-mode" }
+        XCTAssertNotNil(permMode)
+        guard case .enumeration(let values) = permMode?.valueType else {
+            XCTFail("Expected enumeration"); return
+        }
+        XCTAssertEqual(values, ["acceptEdits", "bypassPermissions", "default", "dontAsk", "plan", "auto"])
+    }
+
+    func testParsesInformalEnum() {
+        let flags = ClaudeCLIFlags.parse(helpOutput: sampleHelp)
+        let effort = flags.first { $0.longName == "--effort" }
+        XCTAssertNotNil(effort)
+        guard case .enumeration(let values) = effort?.valueType else {
+            XCTFail("Expected enumeration"); return
+        }
+        XCTAssertEqual(values, ["low", "medium", "high", "max"])
+    }
+
+    func testParsesFreeTextValue() {
+        let flags = ClaudeCLIFlags.parse(helpOutput: sampleHelp)
+        let model = flags.first { $0.longName == "--model" }
+        XCTAssertNotNil(model)
+        XCTAssertEqual(model?.valueType, .freeText)
+        XCTAssertEqual(model?.valuePlaceholder, "<model>")
+    }
+
+    func testBlocklistExcludesInternalFlags() {
+        let flags = ClaudeCLIFlags.parse(helpOutput: sampleHelp)
+        let longNames = flags.map(\.longName)
+        XCTAssertFalse(longNames.contains("--continue"))
+        XCTAssertFalse(longNames.contains("--print"))
+        XCTAssertFalse(longNames.contains("--version"))
+        XCTAssertFalse(longNames.contains("--help"))
+        XCTAssertFalse(longNames.contains("--resume"))
+    }
+
+    func testParsesAliasedFlag() {
+        let flags = ClaudeCLIFlags.parse(helpOutput: sampleHelp)
+        // --allowedTools, --allowed-tools should produce one entry
+        let allowed = flags.first { $0.longName == "--allowed-tools" }
+        XCTAssertNotNil(allowed)
+        XCTAssertEqual(allowed?.valueType, .freeText)
+    }
+
+    func testEmptyInputReturnsEmptyArray() {
+        let flags = ClaudeCLIFlags.parse(helpOutput: "")
+        XCTAssertTrue(flags.isEmpty)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `xcodebuild -project Deckard.xcodeproj -scheme Deckard build 2>&1 | tail -5`
+Expected: Build FAILS — `ClaudeCLIFlags` not defined.
+
+- [ ] **Step 3: Implement ClaudeCLIFlags model and parser**
+
+Create `Sources/App/ClaudeCLIFlags.swift`:
+
+```swift
+import Foundation
+
+/// Represents a single CLI flag parsed from `claude --help`.
+struct ClaudeFlag {
+    let longName: String
+    let shortName: String?
+    let description: String
+    let valueType: ValueType
+    let valuePlaceholder: String?
+
+    enum ValueType: Equatable {
+        case boolean
+        case freeText
+        case enumeration([String])
+    }
+}
+
+/// Parses and caches CLI flags from `claude --help`.
+final class ClaudeCLIFlags {
+
+    static let shared = ClaudeCLIFlags()
+
+    /// Parsed flags. Empty until `load()` completes (or if claude is not installed).
+    private(set) var flags: [ClaudeFlag] = []
+
+    /// Flags Deckard manages internally — excluded from suggestions.
+    static let blocklist: Set<String> = [
+        "--resume", "--continue", "--fork-session", "--print", "--version", "--help",
+        "--output-format", "--input-format", "--include-partial-messages",
+        "--replay-user-messages", "--json-schema", "--max-budget-usd",
+        "--no-session-persistence", "--fallback-model", "--from-pr", "--session-id",
+    ]
+
+    /// Run `claude --help` asynchronously and parse the output.
+    func load() {
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            guard let output = Self.runClaudeHelp() else { return }
+            let parsed = Self.parse(helpOutput: output)
+            DispatchQueue.main.async {
+                self?.flags = parsed
+            }
+        }
+    }
+
+    /// Parse `claude --help` output into structured flags.
+    static func parse(helpOutput: String) -> [ClaudeFlag] {
+        // Matches lines like:
+        //   --flag <value>        Description text
+        //   -s, --flag <value>    Description text
+        //   --aliasA, --aliasB <value>  Description text
+        let pattern = #"^\s+(?:(-\w),\s+)?(?:--[\w-]+,\s+)*(--[\w-]+)(?:\s+[\[<]([^\]>]+)[\]>](?:\.{3})?)?\s{2,}(.+)$"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: .anchorsMatchLines) else {
+            return []
+        }
+
+        var results: [ClaudeFlag] = []
+        let nsString = helpOutput as NSString
+
+        regex.enumerateMatches(in: helpOutput, range: NSRange(location: 0, length: nsString.length)) { match, _, _ in
+            guard let match else { return }
+
+            let shortName = match.range(at: 1).location != NSNotFound
+                ? nsString.substring(with: match.range(at: 1)) : nil
+            let longName = nsString.substring(with: match.range(at: 2))
+            let placeholder = match.range(at: 3).location != NSNotFound
+                ? nsString.substring(with: match.range(at: 3)) : nil
+            let desc = nsString.substring(with: match.range(at: 4))
+                // Collapse multi-space runs from column alignment
+                .replacingOccurrences(of: "  +", with: " ", options: .regularExpression)
+
+            // Skip blocklisted flags
+            if blocklist.contains(longName) { return }
+
+            let valueType = Self.determineValueType(placeholder: placeholder, description: desc)
+
+            results.append(ClaudeFlag(
+                longName: longName,
+                shortName: shortName,
+                description: desc,
+                valueType: valueType,
+                valuePlaceholder: placeholder.map { "<\($0)>" }
+            ))
+        }
+
+        return results
+    }
+
+    /// Determine the value type from the placeholder and description.
+    private static func determineValueType(placeholder: String?, description: String) -> ClaudeFlag.ValueType {
+        guard placeholder != nil else { return .boolean }
+
+        // Explicit choices: (choices: "a", "b", "c")
+        if let choicesMatch = description.range(of: #"\(choices:\s*(.+?)\)"#, options: .regularExpression) {
+            let choicesStr = String(description[choicesMatch])
+            // Extract quoted values
+            let quotedPattern = #""([^"]+)""#
+            if let quotedRegex = try? NSRegularExpression(pattern: quotedPattern) {
+                let nsStr = choicesStr as NSString
+                let matches = quotedRegex.matches(in: choicesStr, range: NSRange(location: 0, length: nsStr.length))
+                let values = matches.map { nsStr.substring(with: $0.range(at: 1)) }
+                if !values.isEmpty {
+                    return .enumeration(values)
+                }
+            }
+        }
+
+        // Informal enum: description ends with (word, word, word)
+        // Heuristic: parenthesized list at end, 2-8 items, each ≤20 chars, no spaces within items
+        if let informalMatch = description.range(of: #"\(([a-zA-Z][\w-]{0,19}(?:,\s*[a-zA-Z][\w-]{0,19}){1,7})\)\s*$"#, options: .regularExpression) {
+            let inner = description[informalMatch]
+                .dropFirst().dropLast() // remove ( and )
+                .trimmingCharacters(in: .whitespace)
+            let items = inner.split(separator: ",").map { $0.trimmingCharacters(in: .whitespace) }
+            if items.count >= 2 && items.count <= 8 && items.allSatisfy({ !$0.contains(" ") && $0.count <= 20 }) {
+                return .enumeration(items)
+            }
+        }
+
+        return .freeText
+    }
+
+    /// Run `claude --help` and return its stdout, or nil on failure.
+    private static func runClaudeHelp() -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["claude", "--help"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe() // discard stderr
+        do {
+            try process.run()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else { return nil }
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            return String(data: data, encoding: .utf8)
+        } catch {
+            return nil
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Build and run tests to verify they pass**
+
+Run: `xcodebuild -project Deckard.xcodeproj -scheme Deckard build 2>&1 | tail -5`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/App/ClaudeCLIFlags.swift Tests/ClaudeCLIFlagsTests.swift
+git commit -m "feat: add ClaudeFlag model and help output parser"
+```
+
+---
+
+### Task 2: Args String Serialization (Round-Trip)
+
+**Files:**
+- Modify: `Sources/App/ClaudeCLIFlags.swift`
+- Modify: `Tests/ClaudeCLIFlagsTests.swift`
+
+- [ ] **Step 1: Write failing tests for serialization**
+
+Add to `Tests/ClaudeCLIFlagsTests.swift`:
+
+```swift
+final class ArgsSerializationTests: XCTestCase {
+
+    func testSerializeChipsToString() {
+        let chips = [
+            ArgsChip(flag: "--permission-mode", value: "auto"),
+            ArgsChip(flag: "--verbose", value: nil),
+            ArgsChip(flag: "--model", value: "sonnet"),
+        ]
+        let result = ArgsChip.serialize(chips)
+        XCTAssertEqual(result, "--permission-mode auto --verbose --model sonnet")
+    }
+
+    func testDeserializeStringToChips() {
+        let input = "--permission-mode auto --verbose --model sonnet"
+        let flags = ClaudeCLIFlags.parse(helpOutput: """
+          --permission-mode <mode>   Permission mode (choices: "auto", "default")
+          --verbose                  Verbose
+          --model <model>            Model
+        """)
+        let chips = ArgsChip.deserialize(input, knownFlags: flags)
+        XCTAssertEqual(chips.count, 3)
+        XCTAssertEqual(chips[0].flag, "--permission-mode")
+        XCTAssertEqual(chips[0].value, "auto")
+        XCTAssertEqual(chips[1].flag, "--verbose")
+        XCTAssertNil(chips[1].value)
+        XCTAssertEqual(chips[2].flag, "--model")
+        XCTAssertEqual(chips[2].value, "sonnet")
+    }
+
+    func testDeserializeUnknownFlags() {
+        let input = "--unknown-flag some-value --verbose"
+        let flags = ClaudeCLIFlags.parse(helpOutput: """
+          --verbose   Verbose
+        """)
+        let chips = ArgsChip.deserialize(input, knownFlags: flags)
+        XCTAssertEqual(chips.count, 2)
+        XCTAssertEqual(chips[0].flag, "--unknown-flag")
+        XCTAssertEqual(chips[0].value, "some-value")
+        XCTAssertEqual(chips[1].flag, "--verbose")
+    }
+
+    func testRoundTrip() {
+        let original = "--permission-mode auto --verbose"
+        let flags = ClaudeCLIFlags.parse(helpOutput: """
+          --permission-mode <mode>   Permission mode (choices: "auto", "default")
+          --verbose                  Verbose
+        """)
+        let chips = ArgsChip.deserialize(original, knownFlags: flags)
+        let serialized = ArgsChip.serialize(chips)
+        XCTAssertEqual(serialized, original)
+    }
+
+    func testDeserializeEmptyString() {
+        let chips = ArgsChip.deserialize("", knownFlags: [])
+        XCTAssertTrue(chips.isEmpty)
+    }
+}
+```
+
+- [ ] **Step 2: Run build to verify it fails**
+
+Run: `xcodebuild -project Deckard.xcodeproj -scheme Deckard build 2>&1 | tail -5`
+Expected: Build FAILS — `ArgsChip` not defined.
+
+- [ ] **Step 3: Implement ArgsChip**
+
+Add to `Sources/App/ClaudeCLIFlags.swift`:
+
+```swift
+/// A single chip representing one CLI argument (flag + optional value).
+struct ArgsChip: Equatable {
+    let flag: String     // e.g. "--permission-mode"
+    let value: String?   // e.g. "auto", nil for boolean flags
+
+    /// Join chips into a CLI argument string.
+    static func serialize(_ chips: [ArgsChip]) -> String {
+        chips.map { chip in
+            if let value = chip.value {
+                return "\(chip.flag) \(value)"
+            }
+            return chip.flag
+        }.joined(separator: " ")
+    }
+
+    /// Parse a CLI argument string into chips, using known flags to determine
+    /// which flags take values. Unknown flags are assumed to take a value if
+    /// the next token doesn't start with "-".
+    static func deserialize(_ string: String, knownFlags: [ClaudeFlag]) -> [ArgsChip] {
+        let tokens = string.split(separator: " ", omittingEmptySubsequences: true).map(String.init)
+        guard !tokens.isEmpty else { return [] }
+
+        let flagMap = Dictionary(uniqueKeysWithValues: knownFlags.map { ($0.longName, $0) })
+        var chips: [ArgsChip] = []
+        var i = 0
+
+        while i < tokens.count {
+            let token = tokens[i]
+            guard token.hasPrefix("-") else {
+                // Bare value without a flag — skip (shouldn't happen in well-formed input)
+                i += 1
+                continue
+            }
+
+            if let known = flagMap[token] {
+                switch known.valueType {
+                case .boolean:
+                    chips.append(ArgsChip(flag: token, value: nil))
+                    i += 1
+                case .freeText, .enumeration:
+                    let value = (i + 1 < tokens.count && !tokens[i + 1].hasPrefix("-"))
+                        ? tokens[i + 1] : nil
+                    chips.append(ArgsChip(flag: token, value: value))
+                    i += (value != nil ? 2 : 1)
+                }
+            } else {
+                // Unknown flag — assume it takes a value if next token doesn't start with "-"
+                let value = (i + 1 < tokens.count && !tokens[i + 1].hasPrefix("-"))
+                    ? tokens[i + 1] : nil
+                chips.append(ArgsChip(flag: token, value: value))
+                i += (value != nil ? 2 : 1)
+            }
+        }
+
+        return chips
+    }
+}
+```
+
+- [ ] **Step 4: Build to verify tests pass**
+
+Run: `xcodebuild -project Deckard.xcodeproj -scheme Deckard build 2>&1 | tail -5`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/App/ClaudeCLIFlags.swift Tests/ClaudeCLIFlagsTests.swift
+git commit -m "feat: add ArgsChip serialization and deserialization"
+```
+
+---
+
+### Task 3: Startup Loading in AppDelegate
+
+**Files:**
+- Modify: `Sources/App/AppDelegate.swift:61` (after hooks install)
+
+- [ ] **Step 1: Add load call after hooks installation**
+
+In `Sources/App/AppDelegate.swift`, after line 61 (`DeckardHooksInstaller.installIfNeeded()`), add:
+
+```swift
+        // Parse Claude CLI flags for autocomplete in settings.
+        log.log("startup", "Loading Claude CLI flags...")
+        ClaudeCLIFlags.shared.load()
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `xcodebuild -project Deckard.xcodeproj -scheme Deckard build 2>&1 | tail -5`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/App/AppDelegate.swift
+git commit -m "feat: load Claude CLI flags at startup for autocomplete"
+```
+
+---
+
+### Task 4: ClaudeArgsField — Chip Layout & Inline Text Field
+
+**Files:**
+- Create: `Sources/Window/ClaudeArgsField.swift`
+
+This task builds the core view: the container with chips and an inline text field. No dropdown yet.
+
+- [ ] **Step 1: Create ClaudeArgsField with chip rendering and text input**
+
+Create `Sources/Window/ClaudeArgsField.swift`:
+
+```swift
+import AppKit
+
+/// A chip-based text field for entering Claude CLI arguments with autocomplete.
+///
+/// Displays accepted arguments as chips (small rounded tags) and provides an
+/// inline text field for typing new arguments. Backed by a plain string in
+/// UserDefaults for backward compatibility.
+final class ClaudeArgsField: NSView {
+
+    /// Called whenever the argument string changes.
+    var onChange: ((String) -> Void)?
+
+    private var chips: [ArgsChip] = []
+    private let chipContainer = NSView()
+    private let textField = NSTextField()
+    private var chipViews: [NSView] = []
+    private var selectedChipIndex: Int?
+    /// When non-nil, the user has selected a valued flag and is now typing its value.
+    private var pendingFlag: ClaudeFlag?
+
+    /// The current argument string.
+    var stringValue: String {
+        get { ArgsChip.serialize(chips) }
+        set { loadChips(from: newValue) }
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    private func setup() {
+        wantsLayer = true
+        layer?.cornerRadius = 6
+        layer?.borderWidth = 1
+        updateBorderColor()
+
+        chipContainer.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(chipContainer)
+
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        textField.isBordered = false
+        textField.drawsBackground = false
+        textField.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        textField.focusRingType = .none
+        textField.placeholderString = "Type a flag name..."
+        textField.delegate = self
+        textField.cell?.sendsActionOnEndEditing = false
+        addSubview(textField)
+
+        NSLayoutConstraint.activate([
+            chipContainer.topAnchor.constraint(equalTo: topAnchor, constant: 4),
+            chipContainer.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 6),
+            chipContainer.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -6),
+
+            textField.topAnchor.constraint(equalTo: chipContainer.bottomAnchor, constant: 2),
+            textField.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 8),
+            textField.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
+            textField.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -4),
+            textField.heightAnchor.constraint(equalToConstant: 22),
+        ])
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateBorderColor()
+    }
+
+    private func updateBorderColor() {
+        layer?.borderColor = NSColor.separatorColor.cgColor
+        layer?.backgroundColor = NSColor.controlBackgroundColor.cgColor
+    }
+
+    // MARK: - Chip Management
+
+    private func loadChips(from string: String) {
+        chips = ArgsChip.deserialize(string, knownFlags: ClaudeCLIFlags.shared.flags)
+        rebuildChipViews()
+    }
+
+    func addChip(_ chip: ArgsChip) {
+        chips.append(chip)
+        rebuildChipViews()
+        onChange?(stringValue)
+    }
+
+    private func removeChip(at index: Int) {
+        guard index >= 0 && index < chips.count else { return }
+        chips.remove(at: index)
+        selectedChipIndex = nil
+        rebuildChipViews()
+        onChange?(stringValue)
+    }
+
+    private func rebuildChipViews() {
+        chipViews.forEach { $0.removeFromSuperview() }
+        chipViews.removeAll()
+
+        // Remove existing height constraint on chipContainer
+        chipContainer.constraints.filter { $0.firstAttribute == .height }.forEach { $0.isActive = false }
+
+        guard !chips.isEmpty else {
+            chipContainer.heightAnchor.constraint(equalToConstant: 0).isActive = true
+            textField.placeholderString = "Type a flag name..."
+            return
+        }
+
+        textField.placeholderString = ""
+
+        // Flow layout: lay out chip views left-to-right, wrapping
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        let spacing: CGFloat = 4
+        let maxWidth = bounds.width - 12 // account for container insets
+
+        for (i, chip) in chips.enumerated() {
+            let view = makeChipView(chip, index: i)
+            let size = view.fittingSize
+            if x + size.width > maxWidth && x > 0 {
+                x = 0
+                y += size.height + spacing
+            }
+            view.frame = NSRect(x: x, y: y, width: size.width, height: size.height)
+            chipContainer.addSubview(view)
+            chipViews.append(view)
+            x += size.width + spacing
+        }
+
+        let totalHeight = y + (chipViews.last?.frame.height ?? 0)
+        chipContainer.heightAnchor.constraint(equalToConstant: totalHeight).isActive = true
+    }
+
+    private func makeChipView(_ chip: ArgsChip, index: Int) -> NSView {
+        let label: String
+        if let value = chip.value {
+            label = "\(chip.flag) \(value)"
+        } else {
+            label = chip.flag
+        }
+
+        let button = NSButton(title: label, target: self, action: #selector(chipClicked(_:)))
+        button.tag = index
+        button.bezelStyle = .inline
+        button.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
+        button.isBordered = true
+        button.wantsLayer = true
+        button.layer?.cornerRadius = 4
+
+        if selectedChipIndex == index {
+            button.layer?.backgroundColor = NSColor.selectedContentBackgroundColor.cgColor
+            button.contentTintColor = .white
+        }
+
+        return button
+    }
+
+    @objc private func chipClicked(_ sender: NSButton) {
+        if selectedChipIndex == sender.tag {
+            // Already selected — deselect
+            selectedChipIndex = nil
+        } else {
+            selectedChipIndex = sender.tag
+        }
+        rebuildChipViews()
+        window?.makeFirstResponder(textField)
+    }
+
+    // MARK: - Keyboard Handling
+
+    override func keyDown(with event: NSEvent) {
+        if event.keyCode == 51 /* Backspace */ {
+            if let idx = selectedChipIndex {
+                removeChip(at: idx)
+                return
+            }
+            if textField.stringValue.isEmpty && !chips.isEmpty {
+                selectedChipIndex = chips.count - 1
+                rebuildChipViews()
+                return
+            }
+        }
+        if event.keyCode == 53 /* Escape */ {
+            selectedChipIndex = nil
+            rebuildChipViews()
+        }
+        super.keyDown(with: event)
+    }
+
+    // MARK: - Layout
+
+    override func layout() {
+        super.layout()
+        rebuildChipViews()
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `xcodebuild -project Deckard.xcodeproj -scheme Deckard build 2>&1 | tail -5`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/Window/ClaudeArgsField.swift
+git commit -m "feat: add ClaudeArgsField with chip layout and inline text field"
+```
+
+---
+
+### Task 5: Suggestion Dropdown Window
+
+**Files:**
+- Modify: `Sources/Window/ClaudeArgsField.swift`
+
+Add the floating suggestion dropdown that shows filtered flag suggestions.
+
+- [ ] **Step 1: Add NSTextFieldDelegate and suggestion window to ClaudeArgsField**
+
+Add to `Sources/Window/ClaudeArgsField.swift`, below the existing code:
+
+```swift
+// MARK: - Suggestion Dropdown
+
+extension ClaudeArgsField: NSTextFieldDelegate, NSTableViewDataSource, NSTableViewDelegate {
+
+    private static var suggestionWindowKey: UInt8 = 0
+    private static var suggestionTableKey: UInt8 = 0
+    private static var filteredFlagsKey: UInt8 = 0
+    private static var selectedRowKey: UInt8 = 0
+
+    private var suggestionWindow: NSWindow {
+        if let w = objc_getAssociatedObject(self, &Self.suggestionWindowKey) as? NSWindow { return w }
+        let w = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 400, height: 200),
+                         styleMask: .borderless, backing: .buffered, defer: true)
+        w.isOpaque = false
+        w.backgroundColor = .clear
+        w.hasShadow = true
+        w.level = .floating
+
+        let visual = NSVisualEffectView(frame: w.contentView!.bounds)
+        visual.autoresizingMask = [.width, .height]
+        visual.material = .popover
+        visual.state = .active
+        visual.wantsLayer = true
+        visual.layer?.cornerRadius = 8
+        visual.layer?.masksToBounds = true
+        w.contentView?.addSubview(visual)
+
+        let scroll = NSScrollView(frame: visual.bounds)
+        scroll.autoresizingMask = [.width, .height]
+        scroll.hasVerticalScroller = true
+        scroll.borderType = .noBorder
+        scroll.drawsBackground = false
+
+        let table = NSTableView()
+        table.headerView = nil
+        table.backgroundColor = .clear
+        table.rowHeight = 36
+        let col = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("Flag"))
+        col.width = 380
+        table.addTableColumn(col)
+        table.dataSource = self
+        table.delegate = self
+
+        scroll.documentView = table
+        visual.addSubview(scroll)
+
+        objc_setAssociatedObject(self, &Self.suggestionTableKey, table, .OBJC_ASSOCIATION_RETAIN)
+        objc_setAssociatedObject(self, &Self.suggestionWindowKey, w, .OBJC_ASSOCIATION_RETAIN)
+        return w
+    }
+
+    private var suggestionTable: NSTableView? {
+        objc_getAssociatedObject(self, &Self.suggestionTableKey) as? NSTableView
+    }
+
+    private var filteredFlags: [ClaudeFlag] {
+        get { (objc_getAssociatedObject(self, &Self.filteredFlagsKey) as? [ClaudeFlag]) ?? [] }
+        set { objc_setAssociatedObject(self, &Self.filteredFlagsKey, newValue, .OBJC_ASSOCIATION_RETAIN) }
+    }
+
+    private var selectedSuggestionRow: Int {
+        get { (objc_getAssociatedObject(self, &Self.selectedRowKey) as? Int) ?? -1 }
+        set { objc_setAssociatedObject(self, &Self.selectedRowKey, newValue, .OBJC_ASSOCIATION_RETAIN) }
+    }
+
+    // MARK: NSTextFieldDelegate
+
+    func controlTextDidChange(_ obj: Notification) {
+        selectedChipIndex = nil
+        let query = textField.stringValue.trimmingCharacters(in: .whitespaces)
+            .replacingOccurrences(of: "^-+", with: "", options: .regularExpression) // strip leading dashes
+
+        if pendingFlag != nil {
+            // User is typing a value for a pending flag — don't show flag suggestions
+            hideSuggestions()
+            return
+        }
+
+        guard !query.isEmpty else {
+            hideSuggestions()
+            return
+        }
+
+        let existingFlags = Set(chips.map(\.flag))
+        let allFlags = ClaudeCLIFlags.shared.flags.filter { !existingFlags.contains($0.longName) }
+
+        // Fuzzy match using Fuse
+        let fuse = Fuse(threshold: 0.4)
+        let scored = allFlags.compactMap { flag -> (ClaudeFlag, Double)? in
+            // Match against the long name without dashes
+            let name = flag.longName.replacingOccurrences(of: "^-+", with: "", options: .regularExpression)
+            if let result = fuse.search(query, in: name) {
+                return (flag, result.score)
+            }
+            // Also try substring match for short queries
+            if name.localizedCaseInsensitiveContains(query) {
+                return (flag, 0.5)
+            }
+            return nil
+        }.sorted { $0.1 < $1.1 }
+
+        filteredFlags = scored.map(\.0)
+        selectedSuggestionRow = filteredFlags.isEmpty ? -1 : 0
+        suggestionTable?.reloadData()
+
+        if filteredFlags.isEmpty {
+            hideSuggestions()
+        } else {
+            showSuggestions()
+        }
+    }
+
+    func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+        if commandSelector == #selector(moveUp(_:)) {
+            if selectedSuggestionRow > 0 {
+                selectedSuggestionRow -= 1
+                suggestionTable?.selectRowIndexes(IndexSet(integer: selectedSuggestionRow), byExtendingSelection: false)
+                suggestionTable?.scrollRowToVisible(selectedSuggestionRow)
+            }
+            return true
+        }
+        if commandSelector == #selector(moveDown(_:)) {
+            if selectedSuggestionRow < filteredFlags.count - 1 {
+                selectedSuggestionRow += 1
+                suggestionTable?.selectRowIndexes(IndexSet(integer: selectedSuggestionRow), byExtendingSelection: false)
+                suggestionTable?.scrollRowToVisible(selectedSuggestionRow)
+            }
+            return true
+        }
+        if commandSelector == #selector(insertTab(_:)) || commandSelector == #selector(insertNewline(_:)) {
+            if pendingFlag != nil {
+                commitPendingFlag()
+                return true
+            }
+            if selectedSuggestionRow >= 0 && selectedSuggestionRow < filteredFlags.count {
+                acceptSuggestion(filteredFlags[selectedSuggestionRow])
+                return true
+            }
+            // If there's typed text that looks like a flag but isn't in suggestions, accept as unknown
+            let typed = textField.stringValue.trimmingCharacters(in: .whitespaces)
+            if typed.hasPrefix("-") {
+                acceptUnknownFlag(typed)
+                return true
+            }
+            return false
+        }
+        if commandSelector == #selector(cancelOperation(_:)) {
+            if pendingFlag != nil {
+                pendingFlag = nil
+                textField.stringValue = ""
+                textField.placeholderString = chips.isEmpty ? "Type a flag name..." : ""
+            }
+            hideSuggestions()
+            return true
+        }
+        if commandSelector == #selector(deleteBackward(_:)) {
+            if textField.stringValue.isEmpty {
+                if let idx = selectedChipIndex {
+                    removeChip(at: idx)
+                    return true
+                }
+                if !chips.isEmpty {
+                    selectedChipIndex = chips.count - 1
+                    rebuildChipViews()
+                    return true
+                }
+            }
+            return false
+        }
+        return false
+    }
+
+    private func acceptSuggestion(_ flag: ClaudeFlag) {
+        hideSuggestions()
+        textField.stringValue = ""
+
+        switch flag.valueType {
+        case .boolean:
+            addChip(ArgsChip(flag: flag.longName, value: nil))
+        case .enumeration(let values):
+            pendingFlag = flag
+            filteredFlags = [] // will be replaced with enum values
+            showEnumChoices(values, for: flag)
+        case .freeText:
+            pendingFlag = flag
+            textField.placeholderString = flag.valuePlaceholder ?? "<value>"
+        }
+    }
+
+    private func showEnumChoices(_ values: [String], for flag: ClaudeFlag) {
+        // Reuse the suggestion window to show enum values
+        // Store enum values as pseudo-flags for table display
+        filteredFlags = values.map { value in
+            ClaudeFlag(longName: value, shortName: nil, description: "Set \(flag.longName) to \(value)",
+                       valueType: .boolean, valuePlaceholder: nil)
+        }
+        selectedSuggestionRow = 0
+        suggestionTable?.reloadData()
+        showSuggestions()
+    }
+
+    private func commitPendingFlag() {
+        guard let flag = pendingFlag else { return }
+
+        if case .enumeration(let values) = flag.valueType,
+           selectedSuggestionRow >= 0 && selectedSuggestionRow < values.count {
+            addChip(ArgsChip(flag: flag.longName, value: values[selectedSuggestionRow]))
+        } else {
+            let value = textField.stringValue.trimmingCharacters(in: .whitespaces)
+            addChip(ArgsChip(flag: flag.longName, value: value.isEmpty ? nil : value))
+        }
+
+        pendingFlag = nil
+        textField.stringValue = ""
+        textField.placeholderString = ""
+        hideSuggestions()
+    }
+
+    private func acceptUnknownFlag(_ text: String) {
+        hideSuggestions()
+        addChip(ArgsChip(flag: text, value: nil))
+        textField.stringValue = ""
+    }
+
+    // MARK: Suggestion Window Positioning
+
+    private func showSuggestions() {
+        guard let parentWindow = window else { return }
+        let fieldRect = textField.convert(textField.bounds, to: nil)
+        let screenRect = parentWindow.convertToScreen(fieldRect)
+        let rows = min(filteredFlags.count, 6)
+        let height = CGFloat(rows) * 36 + 4
+        suggestionWindow.setFrame(NSRect(x: screenRect.minX, y: screenRect.minY - height - 2,
+                                         width: max(screenRect.width, 400), height: height), display: true)
+        if !suggestionWindow.isVisible {
+            parentWindow.addChildWindow(suggestionWindow, ordered: .above)
+        }
+        if selectedSuggestionRow >= 0 {
+            suggestionTable?.selectRowIndexes(IndexSet(integer: selectedSuggestionRow), byExtendingSelection: false)
+        }
+    }
+
+    private func hideSuggestions() {
+        if suggestionWindow.isVisible {
+            suggestionWindow.parent?.removeChildWindow(suggestionWindow)
+            suggestionWindow.orderOut(nil)
+        }
+    }
+
+    // MARK: NSTableViewDataSource
+
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        filteredFlags.count
+    }
+
+    // MARK: NSTableViewDelegate
+
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        let flag = filteredFlags[row]
+        let cell = NSTableCellView()
+
+        let nameLabel = NSTextField(labelWithString: flag.longName)
+        nameLabel.font = .monospacedSystemFont(ofSize: 12, weight: .medium)
+        nameLabel.textColor = .labelColor
+
+        let descLabel = NSTextField(labelWithString: flag.description)
+        descLabel.font = .systemFont(ofSize: 11)
+        descLabel.textColor = .secondaryLabelColor
+        descLabel.lineBreakMode = .byTruncatingTail
+
+        let stack = NSStackView(views: [nameLabel, descLabel])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 1
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        cell.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 8),
+            stack.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -8),
+            stack.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+        ])
+
+        return cell
+    }
+
+    func tableViewSelectionDidChange(_ notification: Notification) {
+        guard let table = suggestionTable else { return }
+        let row = table.selectedRow
+        if row >= 0 {
+            selectedSuggestionRow = row
+        }
+    }
+
+    func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool {
+        true
+    }
+}
+```
+
+Note: This uses associated objects for the suggestion window state to keep the extension clean. The `Fuse` import needs to be added at the top of the file.
+
+- [ ] **Step 2: Add Fuse import at the top of ClaudeArgsField.swift**
+
+Add `import Fuse` after `import AppKit` at the top of the file.
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `xcodebuild -project Deckard.xcodeproj -scheme Deckard build 2>&1 | tail -5`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/Window/ClaudeArgsField.swift
+git commit -m "feat: add suggestion dropdown with fuzzy matching to ClaudeArgsField"
+```
+
+---
+
+### Task 6: Integrate into Settings General Pane
+
+**Files:**
+- Modify: `Sources/Window/SettingsWindow.swift:123-141`
+
+- [ ] **Step 1: Replace NSTextField with ClaudeArgsField in settings**
+
+In `Sources/Window/SettingsWindow.swift`, replace lines 123-134 (the `extraArgsField` creation block):
+
+Old code:
+```swift
+        // Extra arguments
+        let extraArgsLabel = NSTextField(labelWithString: "Extra arguments:")
+        extraArgsLabel.alignment = .right
+
+        let extraArgsField = NSTextField()
+        extraArgsField.stringValue = UserDefaults.standard.string(forKey: "claudeExtraArgs") ?? ""
+        extraArgsField.placeholderString = "--permission-mode auto"
+        extraArgsField.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        objc_setAssociatedObject(extraArgsField, &settingsKeyAssoc, "claudeExtraArgs", .OBJC_ASSOCIATION_RETAIN)
+        extraArgsField.delegate = self
+        extraArgsField.target = self
+        extraArgsField.action = #selector(textFieldChanged(_:))
+
+        grid.addRow(with: [extraArgsLabel, extraArgsField])
+```
+
+New code:
+```swift
+        // Extra arguments
+        let extraArgsLabel = NSTextField(labelWithString: "Extra arguments:")
+        extraArgsLabel.alignment = .right
+
+        let extraArgsField = ClaudeArgsField(frame: NSRect(x: 0, y: 0, width: 400, height: 60))
+        extraArgsField.stringValue = UserDefaults.standard.string(forKey: "claudeExtraArgs") ?? ""
+        extraArgsField.translatesAutoresizingMaskIntoConstraints = false
+        extraArgsField.heightAnchor.constraint(greaterThanOrEqualToConstant: 36).isActive = true
+        extraArgsField.onChange = { newValue in
+            UserDefaults.standard.set(newValue, forKey: "claudeExtraArgs")
+        }
+
+        grid.addRow(with: [extraArgsLabel, extraArgsField])
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `xcodebuild -project Deckard.xcodeproj -scheme Deckard build 2>&1 | tail -5`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/Window/SettingsWindow.swift
+git commit -m "feat: use ClaudeArgsField in settings general pane"
+```
+
+---
+
+### Task 7: Integrate into Per-Session Dialog
+
+**Files:**
+- Modify: `Sources/Window/DeckardWindowController.swift:744-769`
+
+- [ ] **Step 1: Replace NSTextField with ClaudeArgsField in per-session dialog**
+
+In `Sources/Window/DeckardWindowController.swift`, replace the field creation in `promptForClaudeArgs()` (lines 751-754):
+
+Old code:
+```swift
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 300, height: 24))
+        field.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        field.stringValue = UserDefaults.standard.string(forKey: "claudeExtraArgs") ?? ""
+        field.placeholderString = "--permission-mode auto"
+        alert.accessoryView = field
+```
+
+New code:
+```swift
+        let field = ClaudeArgsField(frame: NSRect(x: 0, y: 0, width: 400, height: 60))
+        field.stringValue = UserDefaults.standard.string(forKey: "claudeExtraArgs") ?? ""
+        alert.accessoryView = field
+```
+
+And update the completion call (line 763) to use `field.stringValue` (this already works since `ClaudeArgsField.stringValue` returns the serialized string):
+
+```swift
+            completion(field.stringValue)
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `xcodebuild -project Deckard.xcodeproj -scheme Deckard build 2>&1 | tail -5`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/Window/DeckardWindowController.swift
+git commit -m "feat: use ClaudeArgsField in per-session args dialog"
+```
+
+---
+
+### Task 8: Manual Testing & Polish
+
+**Files:**
+- Possibly modify: `Sources/Window/ClaudeArgsField.swift` (visual tweaks)
+
+- [ ] **Step 1: Build the app**
+
+Run: `xcodebuild -project Deckard.xcodeproj -scheme Deckard -configuration Debug build 2>&1 | tail -5`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 2: Manual test checklist**
+
+After launching the app (with user permission), verify:
+
+1. Open Settings → General pane → "Extra arguments" field shows chips for any previously saved args
+2. Click in the field and type "perm" → dropdown shows `--permission-mode`
+3. Select `--permission-mode` → dropdown shows enum values (auto, default, etc.)
+4. Select "auto" → chip `--permission-mode auto` appears
+5. Type "verb" → dropdown shows `--verbose`, select it → chip appears immediately (boolean)
+6. Press Backspace on empty field → last chip becomes selected
+7. Press Backspace again → selected chip is deleted
+8. Blocked flags (--resume, --print, etc.) do not appear in suggestions
+9. Close settings → reopen → chips persist correctly
+10. Test per-session dialog (enable "Customize arguments per session", create new Claude tab)
+
+- [ ] **Step 3: Fix any visual or behavioral issues found**
+
+Address issues found in manual testing.
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add -A
+git commit -m "fix: polish ClaudeArgsField visual and interaction issues"
+```

--- a/docs/superpowers/specs/2026-03-31-claude-args-autocomplete-design.md
+++ b/docs/superpowers/specs/2026-03-31-claude-args-autocomplete-design.md
@@ -1,0 +1,128 @@
+# Claude CLI Args Autocomplete — Design Spec
+
+## Overview
+
+Replace the plain text field for Claude CLI start parameters (in Settings and the per-session dialog) with a smart chip-based field that autocompletes CLI flags and their values, powered by dynamically parsing `claude --help` at Deckard startup.
+
+## 1. CLI Flag Discovery & Parsing
+
+### Model
+
+```swift
+struct ClaudeFlag {
+    let longName: String           // "--permission-mode"
+    let shortName: String?         // "-p", "-c", etc.
+    let description: String        // "Permission mode to use..."
+    let valueType: ValueType       // .boolean, .freeText, .enum([...])
+    let valuePlaceholder: String?  // "<mode>", "<path>", etc.
+}
+
+enum ValueType {
+    case boolean                   // no argument needed
+    case freeText                  // user types a value
+    case enumeration([String])     // choices parsed from help
+}
+```
+
+### Parsing strategy
+
+- Run `claude --help` via `Process` at Deckard startup (async, non-blocking).
+- Regex-match each option line:
+  - `--flag-name <placeholder>` → flag takes a value; no `<>` → boolean.
+  - Extract `(choices: "a", "b", "c")` for explicit enums (regex: `\(choices:\s*(.+?)\)` then split on comma).
+  - Extract informal enums: when the description ends with a parenthesized comma-separated list of short lowercase words (e.g., `(low, medium, high, max)`), treat as enum. Heuristic: all items ≤20 chars, no spaces within items, 2-8 items.
+- Cache the parsed result in memory. Re-parse on next launch.
+- If `claude` isn't installed or `--help` fails, degrade gracefully — the field behaves as a plain text field.
+
+### Blocklist
+
+Flags Deckard manages internally, excluded from suggestions:
+
+`--resume`, `--continue`, `--fork-session`, `--print`, `--version`, `--help`, `--output-format`, `--input-format`, `--include-partial-messages`, `--replay-user-messages`, `--json-schema`, `--max-budget-usd`, `--no-session-persistence`, `--fallback-model`, `--from-pr`, `--session-id`
+
+## 2. ClaudeArgsField UI Component
+
+A reusable `NSView` subclass used in both Settings and the per-session dialog.
+
+### Layout
+
+- A styled container view (rounded rect, monospaced font, matching current field appearance).
+- Inside: a horizontal flow layout with **chips** (for accepted flags) and an **inline text field** (for typing).
+- The text field occupies remaining space after chips, wrapping to next line if needed.
+
+### Chips
+
+- Each chip represents one accepted argument (e.g., `--permission-mode auto` or `--verbose`).
+- Styled with a subtle background color, rounded corners, monospaced font.
+- Click a chip to select it, press Backspace to delete.
+- Chips are not editable — delete and re-add to change.
+
+### Suggestion dropdown
+
+- A floating `NSWindow` positioned below the text field, containing an `NSTableView`.
+- Appears automatically when the user starts typing (no trigger key required).
+- Each row shows: flag name (bold) + short description (dimmed).
+- Fuzzy-filters on the typed text, matching against flag name **without requiring `--` prefix** (typing "perm" matches `--permission-mode`).
+- Keyboard: Up/Down to navigate, Tab/Enter to accept, Escape to dismiss.
+- Already-added flags are hidden from suggestions (no duplicates).
+
+### Two-step flow for valued flags
+
+1. User types, selects a flag like `--permission-mode` → flag name appears as provisional text.
+2. If the flag has **enum values** → dropdown immediately shows the enum choices.
+3. If the flag has **free-text value** → dropdown dismisses, user types the value, Enter/Space commits the chip.
+4. If the flag is **boolean** → chip is created immediately.
+
+### Serialization
+
+- The field stores its value as a plain string in UserDefaults (same `claudeExtraArgs` key).
+- On load: parse the string into chips (split by known flag boundaries).
+- On save: join chips back into a CLI string (`--permission-mode auto --verbose`).
+- Backward compatible — no migration needed.
+
+## 3. Integration Points
+
+### Settings General Pane (`SettingsWindow.swift`)
+
+- Replace the current `NSTextField` for `claudeExtraArgs` (around line 123) with a `ClaudeArgsField` instance.
+- Same grid row, same label, same UserDefaults key.
+
+### Per-Session Dialog (`DeckardWindowController.swift`)
+
+- Replace the `NSTextField` in `promptForClaudeArgs()` (around line 744) with a `ClaudeArgsField`.
+- `NSAlert.accessoryView` becomes the `ClaudeArgsField`.
+- Slightly wider frame (~400pt) to accommodate chips.
+
+### Startup Parsing (`AppDelegate.swift`)
+
+- On app launch, run `claude --help` via `Process`, parse output into `[ClaudeFlag]`.
+- Store as a shared singleton: `ClaudeCLIFlags.shared.flags`.
+- Async — don't block app launch. Field works as plain text until parsing completes.
+- If `claude` is not found or help fails, `flags` stays empty → plain text behavior.
+
+### File organization
+
+- `Sources/Window/ClaudeArgsField.swift` — the custom NSView (chips + text field + dropdown).
+- `Sources/App/ClaudeCLIFlags.swift` — parsing `claude --help`, the `ClaudeFlag` model, blocklist, singleton.
+
+## 4. Testing & Edge Cases
+
+### Unit tests
+
+- **Help parser tests**: feed sample `claude --help` output, verify flags extracted correctly — boolean vs valued vs enum, short names, descriptions, choices parsing (both `(choices: ...)` and informal `(low, medium, high, max)` formats).
+- **Blocklist tests**: verify blocked flags are excluded from parsed results.
+- **Serialization round-trip**: chips → string → chips produces identical results.
+
+### Edge cases
+
+- `claude` not installed → graceful fallback to plain text field.
+- `claude --help` output format changes → parser returns partial results, unrecognized lines skipped.
+- User pastes raw args string → parsed into chips on paste.
+- Unknown flags (not in help output) → accepted as-is into a chip (don't block the user).
+- Duplicate flag entry → already-added flags hidden from dropdown, but not forcibly prevented.
+
+### Not in scope
+
+- Validating flag combinations (e.g., `--fork-session` requires `--resume`).
+- Auto-updating the flag list while the app is running (only at launch).
+- Persisting the parsed flag data to disk (in-memory only, re-parsed each launch).


### PR DESCRIPTION
Ref #46

## Summary

- Adds a chip-based autocomplete field for Claude CLI start parameters in Settings and the per-session dialog
- Parses `claude --help` at startup to dynamically discover all CLI flags, their value types (boolean/enum/free-text), and enum choices
- Fuzzy-matches flag names as you type (no `--` prefix required), with a two-step flow: pick flag → pick/type value
- Flags Deckard manages internally (--resume, --print, etc.) are filtered from suggestions
- Backward compatible — stores args as the same plain string in UserDefaults

## New files

- `Sources/App/ClaudeCLIFlags.swift` — model, parser, blocklist, singleton
- `Sources/Window/ClaudeArgsField.swift` — chip-based NSView with suggestion dropdown
- `Tests/ClaudeCLIFlagsTests.swift` — 13 unit tests (parser + serialization)

## Test plan

- [ ] Open Settings → General → verify "Extra arguments" field shows chip-based UI
- [ ] Type "perm" → verify `--permission-mode` appears in dropdown
- [ ] Select `--permission-mode` → verify enum values (auto, default, etc.) appear
- [ ] Select "auto" → verify chip `--permission-mode auto` is created
- [ ] Type "verb" → select `--verbose` → verify boolean chip created immediately
- [ ] Backspace on empty field → last chip selected → Backspace again → chip deleted
- [ ] Verify blocked flags (--resume, --print, --help) don't appear in suggestions
- [ ] Close/reopen Settings → verify chips persist correctly
- [ ] Enable "Customize arguments per session" → create Claude tab → verify autocomplete works in dialog
- [ ] Paste a raw args string → verify it's parsed into chips

🤖 Generated with [Claude Code](https://claude.com/claude-code)