### PR TITLE
fix: suppress unseen badges for Claude tabs restored during startup

### DIFF
--- a/Sources/Detection/HookHandler.swift
+++ b/Sources/Detection/HookHandler.swift
@@ -11,6 +11,8 @@ class HookHandler {
 
         case "hook.session-start":
             if let surfaceId = message.surfaceId {
+                // Tab is now restored — re-enable unseen tracking.
+                windowController?.tabForSurfaceId(surfaceId)?.suppressUnseen = false
                 windowController?.updateBadge(forSurfaceId: surfaceId, state: .waitingForInput)
                 windowController?.revealClaudeTab(surfaceId: surfaceId)
                 // Capture the real session ID from Claude Code

--- a/Sources/Window/DeckardWindowController.swift
+++ b/Sources/Window/DeckardWindowController.swift
@@ -20,6 +20,8 @@ class TabItem {
     var isClaude: Bool
     var sessionId: String?
     var badgeState: BadgeState = .none
+    /// Set during restore — suppresses completedUnseen until hook.session-start fires.
+    var suppressUnseen: Bool = false
 
     enum BadgeState: String {
         case none
@@ -647,6 +649,9 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
         let tab = TabItem(surface: surface, name: tabName, isClaude: isClaude)
         surface.tabId = tab.id
         tab.badgeState = isClaude ? .idle : .terminalIdle
+        if isClaude && isRestoring {
+            tab.suppressUnseen = true
+        }
         var envVars: [String: String] = [:]
         if isClaude {
             tab.sessionId = sessionIdToResume
@@ -1141,9 +1146,9 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
         let visible = isTabVisible(surfaceIdStr)
         let idleState: TabItem.BadgeState = isClaude ? .waitingForInput : .terminalIdle
         let unseenState: TabItem.BadgeState = isClaude ? .completedUnseen : .terminalCompletedUnseen
-        let newState = (wasBusy && !visible) ? unseenState : idleState
+        let newState = (wasBusy && !visible && !tab.suppressUnseen) ? unseenState : idleState
         DiagnosticLog.shared.log("badge",
-            "updateBadgeToIdleOrUnseen: surfaceId=\(surfaceIdStr) wasBusy=\(wasBusy) visible=\(visible) -> \(newState)")
+            "updateBadgeToIdleOrUnseen: surfaceId=\(surfaceIdStr) wasBusy=\(wasBusy) visible=\(visible) suppress=\(tab.suppressUnseen) -> \(newState)")
         tab.badgeState = newState
         rebuildSidebar()
         rebuildTabBar()


### PR DESCRIPTION
## Summary
- Adds a `suppressUnseen` flag to `TabItem`, set on Claude tabs created during restore
- Cleared when `hook.session-start` fires (session fully restored)
- `updateBadgeToIdleOrUnseen` skips `completedUnseen` while the flag is set
- Prevents resumed sessions from being incorrectly marked as "unvisited" due to initialization events arriving before session-start

## Test plan
- [ ] Restart Deckard with multiple Claude tabs in "ready" state
- [ ] Verify restored tabs show purple (waitingForInput) not pink (completedUnseen)
- [ ] After restart, submit a prompt in a non-visible tab, verify it correctly shows as unvisited when done

🤖 Generated with [Claude Code](https://claude.com/claude-code)