### PR TITLE
fix: only write state.json when state has changed

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -128,7 +128,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
-        windowController?.saveState()
+        if let wc = windowController {
+            SessionManager.shared.save(wc.captureState())
+        }
         ControlSocket.shared.stop()
     }
 

--- a/Sources/Session/SessionState.swift
+++ b/Sources/Session/SessionState.swift
@@ -113,8 +113,12 @@ class SessionManager {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         guard let data = try? encoder.encode(state) else { return }
-        try? data.write(to: stateURL, options: .atomic)
-        isDirty = false
+        do {
+            try data.write(to: stateURL, options: .atomic)
+            isDirty = false
+        } catch {
+            // Write failed — keep isDirty true so the next autosave cycle retries.
+        }
     }
 
     func load() -> DeckardState? {

--- a/Sources/Session/SessionState.swift
+++ b/Sources/Session/SessionState.swift
@@ -102,12 +102,19 @@ class SessionManager {
     }()
 
     private var autosaveTimer: Timer?
+    private(set) var isDirty = false
+
+    /// Mark state as changed so the next autosave cycle writes to disk.
+    func markDirty() {
+        isDirty = true
+    }
 
     func save(_ state: DeckardState) {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         guard let data = try? encoder.encode(state) else { return }
         try? data.write(to: stateURL, options: .atomic)
+        isDirty = false
     }
 
     func load() -> DeckardState? {
@@ -118,7 +125,8 @@ class SessionManager {
     func startAutosave(provider: @escaping () -> DeckardState) {
         autosaveTimer?.invalidate()
         autosaveTimer = Timer.scheduledTimer(withTimeInterval: 8, repeats: true) { [weak self] _ in
-            self?.save(provider())
+            guard let self, self.isDirty else { return }
+            self.save(provider())
         }
     }
 

--- a/Sources/Window/DeckardWindowController.swift
+++ b/Sources/Window/DeckardWindowController.swift
@@ -1244,7 +1244,7 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
     }
 
     func saveState() {
-        SessionManager.shared.save(captureState())
+        SessionManager.shared.markDirty()
     }
 
     private func restoreOrCreateInitial() {


### PR DESCRIPTION
## Summary

- Adds a dirty flag to `SessionManager` so the 8-second autosave timer only writes `state.json` when state has actually changed
- `saveState()` now marks the state dirty (letting autosave coalesce writes) instead of writing immediately on every call
- On app quit (`applicationWillTerminate`), state is flushed directly to avoid data loss

This eliminates ~95%+ of redundant disk writes that were triggering macOS disk write throttling after ~3 hours of use (~2 GB / ~1,350 atomic writes).

Closes #60

## Test plan

- [ ] Open Deckard, make tab/project changes — verify state persists after restart
- [ ] Leave Deckard idle for several minutes — verify no disk writes via `fs_usage` or Activity Monitor
- [ ] Force-quit Deckard mid-session — verify state is restored (within 8s window)
- [ ] Quit Deckard normally — verify all state is saved (immediate flush on quit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)