### PR TITLE
fix: set TERM_PROGRAM and COLORTERM env vars for terminal identification

### DIFF
--- a/Sources/Terminal/TerminalSurface.swift
+++ b/Sources/Terminal/TerminalSurface.swift
@@ -157,6 +157,10 @@ class TerminalSurface: NSObject, LocalProcessTerminalViewDelegate {
         // Build environment
         var env = ProcessInfo.processInfo.environment
         env["TERM"] = "xterm-256color"
+        env["COLORTERM"] = "truecolor"
+        // Advertise terminal identity so CLI tools (e.g. Claude Code) can detect
+        // Kitty keyboard protocol support for Shift+Enter and other modified keys.
+        env["TERM_PROGRAM"] = "Deckard"
         // Ensure UTF-8 locale for proper emoji/wide character handling in tmux
         if env["LANG"] == nil && env["LC_ALL"] == nil {
             env["LANG"] = "en_US.UTF-8"


### PR DESCRIPTION
Fixes #73

## Summary

- Set `TERM_PROGRAM=Deckard` — standard terminal identification variable, used by CLI tools to detect terminal capabilities
- Set `COLORTERM=truecolor` — advertises 24-bit color support

## Why

Deckard was not setting `TERM_PROGRAM`, so CLI tools (notably Claude Code) could not identify it as a terminal that supports the Kitty keyboard protocol. This caused Shift+Enter to submit prompts instead of inserting newlines.

When Deckard is launched from Dock/Spotlight/Raycast, no terminal identification env vars are present. When launched from another terminal (e.g. Kitty, iTerm2), their env vars leak into Deckard's process and Claude Code works correctly — confirming the issue is purely about terminal detection.

## Next step

After this merges, a bug report on [anthropics/claude-code](https://github.com/anthropics/claude-code) is needed to add "Deckard" to their list of recognized KKP-capable terminals.

## Test plan

- [x] All existing tests pass
- [x] Verified `TERM_PROGRAM=Deckard` and `COLORTERM=truecolor` appear in shell environment via `env | grep -E 'TERM_PROGRAM|COLORTERM'`