### PR TITLE
feat: add TCC usage descriptions and entitlements for child process permissions

### DIFF
--- a/Resources/Deckard.entitlements
+++ b/Resources/Deckard.entitlements
@@ -6,19 +6,5 @@
 	<false/>
 	<key>com.apple.security.network.client</key>
 	<true/>
-	<key>com.apple.security.personal-information.calendars</key>
-	<true/>
-	<key>com.apple.security.personal-information.addressbook</key>
-	<true/>
-	<key>com.apple.security.personal-information.photos-library</key>
-	<true/>
-	<key>com.apple.security.personal-information.location</key>
-	<true/>
-	<key>com.apple.security.device.camera</key>
-	<true/>
-	<key>com.apple.security.device.audio-input</key>
-	<true/>
-	<key>com.apple.security.automation.apple-events</key>
-	<true/>
 </dict>
 </plist>

--- a/Resources/Deckard.entitlements
+++ b/Resources/Deckard.entitlements
@@ -6,5 +6,19 @@
 	<false/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.personal-information.calendars</key>
+	<true/>
+	<key>com.apple.security.personal-information.addressbook</key>
+	<true/>
+	<key>com.apple.security.personal-information.photos-library</key>
+	<true/>
+	<key>com.apple.security.personal-information.location</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
 </dict>
 </plist>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -52,5 +52,13 @@
 	<string>A program running inside Deckard would like to access your location information.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>A program running inside Deckard would like to access your photo library.</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>A program running inside Deckard would like to access Bluetooth.</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>A program running inside Deckard would like to access the local network.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>A program running inside Deckard would like to access speech recognition.</string>
+	<key>NSSystemAdministrationUsageDescription</key>
+	<string>A program running inside Deckard requires elevated privileges.</string>
 </dict>
 </plist>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -36,5 +36,21 @@
 	<string>Deckard needs access to your Desktop folder to open projects and run terminal sessions in those directories.</string>
 	<key>NSDownloadsFolderUsageDescription</key>
 	<string>Deckard needs access to your Downloads folder to open projects and run terminal sessions in those directories.</string>
+	<key>NSRemindersUsageDescription</key>
+	<string>A program running inside Deckard would like to access your reminders.</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>A program running inside Deckard would like to access your calendar data.</string>
+	<key>NSContactsUsageDescription</key>
+	<string>A program running inside Deckard would like to access your contacts.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>A program running inside Deckard would like to access the camera.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>A program running inside Deckard would like to access the microphone.</string>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>A program running inside Deckard would like to access AppleScript.</string>
+	<key>NSLocationUsageDescription</key>
+	<string>A program running inside Deckard would like to access your location information.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>A program running inside Deckard would like to access your photo library.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

- Add `NS*UsageDescription` keys to Info.plist for all TCC-protected resources that child processes (MCP servers, CLI tools) may need: Reminders, Calendars, Contacts, Camera, Microphone, AppleScript, Location, Photos, Bluetooth, Local Network, Speech Recognition, and System Administration
- Remove sandbox-only entitlements (`com.apple.security.personal-information.*`, `com.apple.security.device.*`, etc.) — these are unnecessary since Deckard runs unsandboxed (`app-sandbox = false`). TCC relies purely on the Info.plist usage description keys for unsandboxed apps.
- Modeled after both kitty's and iTerm2's Info.plist

Fixes #79

## Test plan

- [x] Build Deckard without the entitlements
- [x] Run an MCP server that accesses Reminders from within Deckard
- [x] Verify macOS shows a permission prompt
- [x] Grant permission and verify the MCP server can read reminders

🤖 Generated with [Claude Code](https://claude.com/claude-code)