### PR TITLE
fix: handle dots in folder names for context bar and recent projects

### DIFF
--- a/Sources/Detection/ContextMonitor.swift
+++ b/Sources/Detection/ContextMonitor.swift
@@ -3,8 +3,11 @@ import Foundation
 extension String {
     /// Encodes a project path into the directory name Claude Code uses under `~/.claude/projects/`.
     /// Resolves symlinks first so the encoded name matches the canonical path the CLI uses.
+    /// The CLI replaces both "/" and "." with "-".
     var claudeProjectDirName: String {
-        (self as NSString).resolvingSymlinksInPath.replacingOccurrences(of: "/", with: "-")
+        (self as NSString).resolvingSymlinksInPath
+            .replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ".", with: "-")
     }
 }
 

--- a/Sources/Window/ProjectPicker.swift
+++ b/Sources/Window/ProjectPicker.swift
@@ -470,9 +470,12 @@ class ProjectPicker: NSObject, NSTableViewDataSource, NSTableViewDelegate, NSTex
     }
 
     /// Decode a Claude Code project directory name back to a filesystem path.
-    /// Claude encodes "/" as "-", so "-Users-gilles-Documents-ai-trend-finder" must
-    /// be decoded by finding which hyphens are path separators and which are literal.
-    /// Strategy: greedily build the path left-to-right, checking if each segment exists.
+    /// Claude encodes both "/" and "." as "-", so "-Users-tibor-code-trogulja-trogulja-github-io"
+    /// must be decoded by finding which hyphens are path separators, dots, or literal dashes.
+    /// Strategy: greedily build the path left-to-right, checking if each segment exists as a
+    /// directory. When the final path doesn't exist, scan the parent for an entry whose name
+    /// (with dots replaced by dashes) matches the last segment — this recovers dotted names
+    /// like "trogulja.github.io".
     static func decodeCloudeProjectPath(_ encoded: String) -> String? {
         let stripped = encoded.hasPrefix("-") ? String(encoded.dropFirst()) : encoded
         let parts = stripped.components(separatedBy: "-")
@@ -494,7 +497,25 @@ class ProjectPicker: NSObject, NSTableViewDataSource, NSTableViewDelegate, NSTex
         }
 
         // Append final segment
-        path += "/" + segment
-        return path
+        let decoded = path + "/" + segment
+
+        var isDir: ObjCBool = false
+        if fm.fileExists(atPath: decoded, isDirectory: &isDir) {
+            return decoded
+        }
+
+        // The final segment may contain dashes that were originally dots.
+        // Scan the parent directory for an entry whose dot-normalized name matches.
+        if fm.fileExists(atPath: path, isDirectory: &isDir), isDir.boolValue,
+           let entries = try? fm.contentsOfDirectory(atPath: path) {
+            for entry in entries {
+                let normalized = entry.replacingOccurrences(of: ".", with: "-")
+                if normalized == segment {
+                    return path + "/" + entry
+                }
+            }
+        }
+
+        return decoded
     }
 }


### PR DESCRIPTION
## Summary

- **Encoder** (`claudeProjectDirName`): add `.` → `-` replacement to match Claude CLI's encoding
- **Decoder** (`decodeCloudeProjectPath`): when decoded path doesn't exist, scan parent directory for an entry whose dot-normalized name matches the final segment

Fixes #83

## Test plan

- [x] Open a Claude session in a folder with dots (e.g., `trogulja.github.io`) → context bar appears
- [x] Open Folder picker shows dotted folder names in recent projects list
- [x] Regular folders without dots still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)