### PR TITLE
fix: ignore SIGPIPE so writes to closed hook sockets cannot kill the app

### DIFF
--- a/Sources/Control/ControlSocket.swift
+++ b/Sources/Control/ControlSocket.swift
@@ -182,6 +182,12 @@ class ControlSocket {
         }
         guard clientFd >= 0 else { return }
 
+        // Hook clients (nc -w 1) time out and close before we reply; the
+        // reply write must fail with EPIPE, not raise SIGPIPE.
+        var noSigpipe: Int32 = 1
+        _ = setsockopt(clientFd, SOL_SOCKET, SO_NOSIGPIPE,
+                       &noSigpipe, socklen_t(MemoryLayout<Int32>.size))
+
         // Read data from the client
         let source = DispatchSource.makeReadSource(fileDescriptor: clientFd, queue: socketQueue)
         source.setEventHandler { [weak self] in

--- a/Sources/Detection/CrashReporter.swift
+++ b/Sources/Detection/CrashReporter.swift
@@ -87,6 +87,11 @@ enum CrashReporter {
         for sig in caughtSignals {
             signal(sig, crashSignalHandler)
         }
+        // SIGPIPE's default action silently kills the process — no crash
+        // report, no chance to handle it. Any write to a peer-closed fd
+        // (control-socket replies to hook clients that timed out, PTY or
+        // child-process pipes) must return EPIPE instead.
+        signal(SIGPIPE, SIG_IGN)
     }
 }
 

--- a/Tests/ControlSocketTests.swift
+++ b/Tests/ControlSocketTests.swift
@@ -111,6 +111,60 @@ final class ControlSocketTests: XCTestCase {
         cs.stop()
     }
 
+    // MARK: - Client disconnects before reply
+
+    /// A hook client (nc -w 1) that times out closes its end before Deckard
+    /// writes the reply. The reply write must not raise SIGPIPE and kill the
+    /// process — this exact scenario crashed a 35-hour session.
+    func testClientDisconnectBeforeReplyDoesNotKillProcess() throws {
+        let cs = makeSocket()
+        let received = expectation(description: "message received")
+        let deferredReply = Mutex<((ControlResponse) -> Void)?>(nil)
+
+        cs.onMessage = { _, reply in
+            // Hold the reply until after the client has disconnected.
+            deferredReply.withLock { $0 = reply }
+            received.fulfill()
+        }
+
+        cs.start()
+        spinRunLoop(0.3)
+
+        // Connect, send a message, and close immediately without reading the reply.
+        let sent = expectation(description: "sent and closed")
+        let path = cs.path
+        DispatchQueue.global().async {
+            let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+            guard fd >= 0 else { return }
+            var addr = sockaddr_un()
+            addr.sun_family = sa_family_t(AF_UNIX)
+            self.withPath(path, into: &addr)
+            let connected = withUnsafePointer(to: &addr) { addrPtr in
+                addrPtr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                    connect(fd, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+                }
+            }
+            if connected == 0 {
+                "{\"command\":\"ping\"}\n".withCString { ptr in
+                    _ = write(fd, ptr, strlen(ptr))
+                }
+            }
+            close(fd)
+            sent.fulfill()
+        }
+
+        wait(for: [received, sent], timeout: 3)
+        // Let the close propagate, then reply into the dead socket.
+        spinRunLoop(0.2)
+        deferredReply.withLock { $0 }?(ControlResponse(ok: true, message: "pong"))
+        spinRunLoop(0.2)
+
+        // Reaching this line at all is the real assertion: without SIGPIPE
+        // protection the write above terminates the test process.
+        XCTAssertTrue(canConnect(to: cs.path), "socket should still be alive")
+        cs.stop()
+    }
+
     // MARK: - Recovery
 
     func testRestartAfterSocketFileRemoved() throws {

--- a/Tests/CrashReporterTests.swift
+++ b/Tests/CrashReporterTests.swift
@@ -82,6 +82,20 @@ final class CrashReporterTests: XCTestCase {
         }
     }
 
+    // MARK: - SIGPIPE
+
+    func testInstallIgnoresSigpipe() {
+        CrashReporter.install()
+
+        // Read the current disposition without changing it.
+        var action = sigaction()
+        sigaction(SIGPIPE, nil, &action)
+        let handler = unsafeBitCast(action.__sigaction_u.__sa_handler, to: UInt.self)
+        let ignored = unsafeBitCast(SIG_IGN, to: UInt.self)
+        XCTAssertEqual(handler, ignored,
+                       "SIGPIPE must be ignored — a write to a closed hook socket would otherwise kill the app")
+    }
+
     // MARK: - Crash report directory creation
 
     func testCrashReportDirectoryExists() {


### PR DESCRIPTION
## Root cause

A 35-hour session died at 01:18 with no crash report. launchd recorded:

```
exited due to SIGPIPE | sent by Deckard Dev[20190], ran for 126512413ms
```

SIGPIPE's default action terminates the process silently — no `.ips` report, no `crash.log` (it is not in `CrashReporter.caughtSignals`), and nothing ever set `SIG_IGN`.

The trigger: Claude Code hook clients connect with `nc -U … -w 1` (1-second timeout), but Deckard writes the reply asynchronously from the main queue (`ControlSocket.swift`). When the main thread is busy for >1s — routine in long sessions with many tabs — `nc` times out and closes its end first, and the raw `write(fd, …)` to the dead socket raises SIGPIPE, killing the whole app. With hooks firing on every tool use, a multi-day session eventually loses this race.

## Fix (two layers)

- `CrashReporter.install()` sets `signal(SIGPIPE, SIG_IGN)` — writes to any peer-closed fd (control socket, PTY, child-process pipes) return `EPIPE` instead of terminating the process. All existing write sites already tolerate failed writes.
- `ControlSocket` sets `SO_NOSIGPIPE` on accepted client fds, so the socket path is safe even in processes that never call `CrashReporter.install()` (e.g. hostless tests).

## Tests (TDD — both watched failing first)

- `testInstallIgnoresSigpipe` — failed with disposition `SIG_DFL` before the fix.
- `testClientDisconnectBeforeReplyDoesNotKillProcess` — reproduces the production crash: client sends a message and closes before the reply. Before the fix the test runner died with **"Test crashed with signal pipe."**; now passes.

Full `DeckardTests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)