### PR TITLE
fix: reject session-start from nested claude processes outside the workspace

### DIFF
--- a/Sources/App/DeckardHooksInstaller.swift
+++ b/Sources/App/DeckardHooksInstaller.swift
@@ -23,6 +23,11 @@ enum DeckardHooksInstaller {
         #           unreliable for resumed sessions but better than nothing if stdin is empty).
         if [ "$EVENT" = "session-start" ]; then
             SID=$(printf '%s' "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('session_id',''))" 2>/dev/null)
+            # The session's cwd lets Deckard reject session ids from nested
+            # claude processes (they inherit DECKARD_SURFACE_ID but run in
+            # unrelated directories, e.g. temp checkouts).
+            SCWD=$(printf '%s' "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('cwd',''))" 2>/dev/null)
+            [ -z "$SCWD" ] && SCWD="$(pwd)"
             if [ -z "$SID" ]; then
                 PID=$$
                 CWD="$(pwd)"
@@ -40,6 +45,7 @@ enum DeckardHooksInstaller {
                 done
             fi
             [ -n "$SID" ] && EXTRA=",\\"sessionId\\":\\"$SID\\""
+            [ -n "$SCWD" ] && EXTRA="$EXTRA,\\"workingDirectory\\":\\"$SCWD\\""
         fi
 
         printf '{"command":"hook.%s","surfaceId":"%s"%s}\\n' "$EVENT" "$DECKARD_SURFACE_ID" "$EXTRA" \\

--- a/Sources/Detection/HookHandler.swift
+++ b/Sources/Detection/HookHandler.swift
@@ -15,9 +15,13 @@ class HookHandler {
                 windowController?.tabForSurfaceId(surfaceId)?.suppressUnseen = false
                 windowController?.updateBadge(forSurfaceId: surfaceId, state: .waitingForInput)
                 windowController?.revealClaudeTab(surfaceId: surfaceId)
-                // Capture the real session ID from Claude Code
+                // Capture the real session ID from Claude Code. The cwd lets
+                // the controller reject session-starts from nested claude
+                // processes that inherited DECKARD_SURFACE_ID.
                 if let sessionId = message.sessionId {
-                    windowController?.updateSessionId(forSurfaceId: surfaceId, sessionId: sessionId)
+                    windowController?.updateSessionId(
+                        forSurfaceId: surfaceId, sessionId: sessionId,
+                        cwd: message.workingDirectory)
                 }
             }
             forwardRateLimits(from: message)

--- a/Sources/Window/DeckardWindowController.swift
+++ b/Sources/Window/DeckardWindowController.swift
@@ -1477,8 +1477,34 @@ class DeckardWindowController: NSWindowController, NSSplitViewDelegate {
 
     // MARK: - Session ID / Badge
 
-    func updateSessionId(forSurfaceId surfaceIdStr: String, sessionId: String) {
+    /// Whether a session-start reported from `cwd` may claim a tab whose
+    /// workspace is at `workspacePath`. Nested claude processes (spawned by
+    /// the tab's own session — subagents, review harnesses) inherit
+    /// DECKARD_SURFACE_ID but run in unrelated directories; adopting their
+    /// session id breaks resume and context tracking for the tab.
+    static func cwdBelongsToWorkspace(_ cwd: String?, workspacePath: String) -> Bool {
+        guard let cwd, !cwd.isEmpty else { return true }
+        func components(_ path: String) -> [String] {
+            // NSString's variant resolves symlinks AND strips /private for
+            // /tmp, /var, /etc — URL.resolvingSymlinksInPath() does neither
+            // consistently, so /tmp and /private/tmp would not match.
+            URL(fileURLWithPath: (path as NSString).resolvingSymlinksInPath)
+                .standardizedFileURL.pathComponents
+        }
+        let cwdParts = components(cwd)
+        let workspaceParts = components(workspacePath)
+        return cwdParts.count >= workspaceParts.count
+            && Array(cwdParts.prefix(workspaceParts.count)) == workspaceParts
+    }
+
+    func updateSessionId(forSurfaceId surfaceIdStr: String, sessionId: String, cwd: String? = nil) {
         guard let tab = tabForSurfaceId(surfaceIdStr) else { return }
+        if let workspace = workspaces.first(where: { ws in ws.tabs.contains(where: { $0.id == tab.id }) }),
+           !Self.cwdBelongsToWorkspace(cwd, workspacePath: workspace.path) {
+            DiagnosticLog.shared.log("session",
+                "Ignoring session-start from nested claude: cwd=\(cwd ?? "") is outside workspace \(workspace.path), sessionId=\(sessionId)")
+            return
+        }
         guard tab.sessionId != sessionId else { return }
         tab.sessionId = sessionId
         SessionManager.shared.saveSessionName(sessionId: sessionId, kind: tab.kind, name: tab.name)

--- a/Tests/DeckardHooksInstallerTests.swift
+++ b/Tests/DeckardHooksInstallerTests.swift
@@ -515,6 +515,30 @@ final class DeckardHooksInstallerTests: XCTestCase {
                        "Hook script should extract session_id from stdin JSON")
     }
 
+    func testHookScriptForwardsSessionCwd() throws {
+        let tempDir = NSTemporaryDirectory() + "deckard-hooks-test-\(UUID().uuidString)/"
+        let hooksDir = tempDir + "hooks/"
+        try FileManager.default.createDirectory(atPath: hooksDir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(atPath: tempDir) }
+
+        let hookPath = hooksDir + "notify.sh"
+        let statusLinePath = hooksDir + "statusline.sh"
+        DeckardHooksInstaller.installHookScript(
+            hookScriptPath: hookPath,
+            statusLineScriptPath: statusLinePath
+        )
+
+        let content = try String(contentsOfFile: hookPath, encoding: .utf8)
+
+        // session-start must report the session's cwd so Deckard can reject
+        // session ids coming from nested claude processes (which inherit
+        // DECKARD_SURFACE_ID but run in unrelated directories).
+        XCTAssertTrue(content.contains("'cwd'"),
+                      "Hook script should extract cwd from stdin JSON")
+        XCTAssertTrue(content.contains("workingDirectory"),
+                      "Hook script should forward the cwd as workingDirectory")
+    }
+
     func testHookScriptFallsBackToPidWalking() throws {
         let tempDir = NSTemporaryDirectory() + "deckard-hooks-test-\(UUID().uuidString)/"
         let hooksDir = tempDir + "hooks/"

--- a/Tests/WindowControllerLogicTests.swift
+++ b/Tests/WindowControllerLogicTests.swift
@@ -3,6 +3,68 @@ import AppKit
 import KeyboardShortcuts
 @testable import Deckard
 
+// MARK: - Session ownership (nested-claude hijack)
+
+/// Nested claude processes (spawned by a tab's session, inheriting
+/// DECKARD_SURFACE_ID) report session-start from their own cwd. Only a cwd
+/// inside the tab's workspace may update the tab's session id.
+final class SessionOwnershipTests: XCTestCase {
+
+    func testCwdBelongsToWorkspaceAcceptsExactPath() {
+        XCTAssertTrue(DeckardWindowController.cwdBelongsToWorkspace(
+            "/Users/x/proj", workspacePath: "/Users/x/proj"))
+    }
+
+    func testCwdBelongsToWorkspaceAcceptsSubdirectory() {
+        XCTAssertTrue(DeckardWindowController.cwdBelongsToWorkspace(
+            "/Users/x/proj/.claude/worktrees/fix-1", workspacePath: "/Users/x/proj"))
+    }
+
+    func testCwdBelongsToWorkspaceAcceptsNilOrEmptyCwd() {
+        XCTAssertTrue(DeckardWindowController.cwdBelongsToWorkspace(
+            nil, workspacePath: "/Users/x/proj"))
+        XCTAssertTrue(DeckardWindowController.cwdBelongsToWorkspace(
+            "", workspacePath: "/Users/x/proj"))
+    }
+
+    func testCwdBelongsToWorkspaceRejectsTempCheckout() {
+        XCTAssertFalse(DeckardWindowController.cwdBelongsToWorkspace(
+            "/private/var/folders/9z/T/reviewer-pr8112-7301",
+            workspacePath: "/Users/x/proj"))
+    }
+
+    func testCwdBelongsToWorkspaceRejectsSiblingWithCommonPrefix() {
+        XCTAssertFalse(DeckardWindowController.cwdBelongsToWorkspace(
+            "/Users/x/proj-other", workspacePath: "/Users/x/proj"))
+    }
+
+    func testCwdBelongsToWorkspaceRejectsParentDirectory() {
+        XCTAssertFalse(DeckardWindowController.cwdBelongsToWorkspace(
+            "/Users/x", workspacePath: "/Users/x/proj"))
+    }
+
+    func testCwdBelongsToWorkspaceResolvesSymlinks() throws {
+        // On macOS /tmp is a symlink to /private/tmp. Symlink resolution only
+        // applies to paths that exist — which cwd and workspace always do.
+        XCTAssertTrue(DeckardWindowController.cwdBelongsToWorkspace(
+            "/tmp", workspacePath: "/private/tmp"))
+        XCTAssertTrue(DeckardWindowController.cwdBelongsToWorkspace(
+            "/private/tmp", workspacePath: "/tmp"))
+
+        let sub = "deckard-ownership-test-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(
+            atPath: "/tmp/\(sub)", withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: "/tmp/\(sub)") }
+        XCTAssertTrue(DeckardWindowController.cwdBelongsToWorkspace(
+            "/private/tmp/\(sub)", workspacePath: "/tmp"))
+    }
+
+    func testCwdBelongsToWorkspaceHandlesTrailingSlash() {
+        XCTAssertTrue(DeckardWindowController.cwdBelongsToWorkspace(
+            "/Users/x/proj/", workspacePath: "/Users/x/proj"))
+    }
+}
+
 final class WindowControllerLogicTests: XCTestCase {
 
     // MARK: - BadgeState raw values


### PR DESCRIPTION
## Root cause

Nested claude processes spawned by a tab's own session (subagents, review harnesses that run `claude` in temp checkouts like `/private/var/folders/…/reviewer-…-pr8112`) **inherit `DECKARD_SURFACE_ID`**, so their `session-start` hooks claimed the tab: `updateSessionId` adopted the subprocess's session id, renamed it in `session-names.json`, and persisted it to `state.json`.

Observed fallout on a long-running tab:

- **Resume breaks after a crash/restart**: the restore path looks for the (hijacked) session's `.jsonl` under the *workspace's* project dir, finds nothing (`DeckardWindowController.swift` nulls the id), and launches a fresh empty `claude` — old tab name, no history.
- **Context bar goes blank**: `getUsage: … no usage found` every 5s, because the tracked transcript lives under the temp dir's encoded project folder.
- `session-names.json` accumulates the tab's name on unrelated subprocess sessions.

## Fix

- The hook script forwards the session's `cwd` (from hook stdin JSON, falling back to `pwd`) as `workingDirectory` on `session-start`.
- `updateSessionId` ignores session-starts whose cwd is **outside the tab's workspace path** and logs them under the `session` category.
- Containment check (`cwdBelongsToWorkspace`) resolves symlinks (`/tmp` ↔ `/private/tmp`), compares whole path components (`/Users/x/proj-other` doesn't match `/Users/x/proj`), and accepts subdirectories (e.g. `.claude/worktrees/…` checkouts).
- Messages without a cwd (older hook script still on disk) are accepted, preserving current behavior until the script is reinstalled on next launch.

## Tests (TDD — watched failing first)

- `SessionOwnershipTests` — 8 cases covering exact path, subdir, nil/empty cwd, temp checkout rejection, sibling-prefix rejection, parent rejection, symlink resolution, trailing slash. The symlink case caught a real API quirk: `URL.resolvingSymlinksInPath()` only normalizes existing paths, so the helper uses `NSString.resolvingSymlinksInPath`.
- `testHookScriptForwardsSessionCwd` — installed hook script must extract `cwd` and forward `workingDirectory`.

Full `DeckardTests` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)