### PR TITLE
fix: remove startup key monitor in defer so it can't leak

### DIFF
--- a/Sources/Terminal/TerminalSurface.swift
+++ b/Sources/Terminal/TerminalSurface.swift
@@ -473,13 +473,19 @@ class TerminalSurface: NSObject, LocalProcessTerminalViewDelegate {
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
                 guard let self else { return }
-                defer { self.terminalView.handlesPasteShortcuts = true }
+                // Always restore input handling and remove the window-wide key
+                // monitor, even if the pending input was consumed elsewhere —
+                // a leaked monitor silently swallows every keystroke for the
+                // window whenever this surface's view is attached.
+                defer {
+                    self.terminalView.handlesPasteShortcuts = true
+                    if let monitor = self.keyEventMonitor {
+                        NSEvent.removeMonitor(monitor)
+                        self.keyEventMonitor = nil
+                    }
+                }
                 guard let input = self.pendingInitialInput else { return }
                 self.pendingInitialInput = nil
-                if let monitor = self.keyEventMonitor {
-                    NSEvent.removeMonitor(monitor)
-                    self.keyEventMonitor = nil
-                }
                 self.sendInput(input)
             }
         }

--- a/Sources/Terminal/TerminalSurface.swift
+++ b/Sources/Terminal/TerminalSurface.swift
@@ -341,6 +341,15 @@ class TerminalSurface: NSObject, LocalProcessTerminalViewDelegate {
                                                name: .deckardScrollbackChanged, object: nil)
     }
 
+    deinit {
+        // Backstop for surfaces released without terminate(): a still-installed
+        // monitor would outlive the surface (its closure retains the view) and
+        // permanently swallow the window's keystrokes.
+        if let monitor = keyEventMonitor {
+            NSEvent.removeMonitor(monitor)
+        }
+    }
+
     /// Apply a color scheme to this terminal.
     func applyColorScheme(_ scheme: TerminalColorScheme) {
         scheme.apply(to: terminalView)
@@ -465,22 +474,34 @@ class TerminalSurface: NSObject, LocalProcessTerminalViewDelegate {
         if let initialInput {
             pendingInitialInput = initialInput
             terminalView.handlesPasteShortcuts = false
+            // Overwriting keyEventMonitor would orphan the previous monitor
+            // inside AppKit — permanently swallowing every keystroke for the
+            // window — so remove any existing one first.
+            if let existing = keyEventMonitor {
+                NSEvent.removeMonitor(existing)
+                keyEventMonitor = nil
+            }
             let view = terminalView
-            keyEventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            let monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
                 // Swallow key events targeting our terminal view's window.
                 if event.window === view.window { return nil }
                 return event
             }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+            keyEventMonitor = monitor
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self, monitor] in
+                // If the surface was deallocated, deinit removes the monitor.
                 guard let self else { return }
-                // Always restore input handling and remove the window-wide key
-                // monitor, even if the pending input was consumed elsewhere —
-                // a leaked monitor silently swallows every keystroke for the
-                // window whenever this surface's view is attached.
+                // Always restore input handling and remove the monitor this
+                // call installed on every exit path — but only if it is still
+                // the active one (terminate() or a later startShell may have
+                // removed or replaced it already; removing a monitor twice is
+                // not allowed).
                 defer {
                     self.terminalView.handlesPasteShortcuts = true
-                    if let monitor = self.keyEventMonitor {
-                        NSEvent.removeMonitor(monitor)
+                    if let current = self.keyEventMonitor,
+                       let monitor,
+                       (current as AnyObject) === (monitor as AnyObject) {
+                        NSEvent.removeMonitor(current)
                         self.keyEventMonitor = nil
                     }
                 }
@@ -502,6 +523,7 @@ class TerminalSurface: NSObject, LocalProcessTerminalViewDelegate {
     func terminate() {
         guard !processExited else { return }
         processExited = true
+        pendingInitialInput = nil
         if let monitor = keyEventMonitor {
             NSEvent.removeMonitor(monitor)
             keyEventMonitor = nil


### PR DESCRIPTION
The +0.3s initial-input closure in `TerminalSurface.startShell` early-returned before removing the window-wide keystroke-swallowing `NSEvent` monitor when `pendingInitialInput` was nil. A leaked monitor silently eats every keystroke for the window whenever the surface's view is attached (latent bug surfaced by the #99 investigation — ruled out as that freeze's cause by live state inspection, but real).

Fix: move monitor removal and `handlesPasteShortcuts` restore into a single `defer` so every exit path cleans up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)